### PR TITLE
Fix cursor misaligned bug in monaco editor

### DIFF
--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -318,6 +318,10 @@ export const MonacoEditor = forwardRef<MonacoEditorRef, Props>(
           runValidation(editor, filenameRef.current);
       });
 
+      document.fonts.ready.then(() => {
+        monaco.editor.remeasureFonts();
+      });
+
       onReadyRef.current?.();
 
       return () => {


### PR DESCRIPTION
Fixes cursor misaligned bug in monaco editor using remeasure fonts method https://github.com/microsoft/monaco-editor/issues/4644