### PR TITLE
perf(geo): cache compiled domain-match regex by pattern

### DIFF
--- a/backend/src/geo.rs
+++ b/backend/src/geo.rs
@@ -8,10 +8,28 @@ use prost::bytes::Buf;
 use prost::encoding::{DecodeContext, WireType, decode_key, decode_varint, skip_field};
 use regex_lite::Regex;
 use serde::Serialize;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, LazyLock, RwLock};
 use std::time::SystemTime;
 use std::{collections::HashMap, fs::File, net::IpAddr, path::Path};
 use tokio::task;
+
+static REGEX_CACHE: LazyLock<RwLock<HashMap<String, Option<Arc<Regex>>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+fn get_or_compile_regex(pattern: &str) -> Option<Arc<Regex>> {
+    {
+        let cache = REGEX_CACHE.read().unwrap();
+        if let Some(slot) = cache.get(pattern) {
+            return slot.clone();
+        }
+    }
+    let compiled = Regex::new(pattern).ok().map(Arc::new);
+    REGEX_CACHE
+        .write()
+        .unwrap()
+        .insert(pattern.to_string(), compiled.clone());
+    compiled
+}
 
 #[derive(Serialize, Clone)]
 pub struct GeoFilesResponse {
@@ -146,7 +164,7 @@ fn parse_domain_and_match(mut buf: &[u8], dom_low: &str) -> bool {
     }
     match domain_type {
         0 => dom_low.contains(value),
-        1 => Regex::new(value).map_or(false, |re: regex_lite::Regex| re.is_match(dom_low)),
+        1 => get_or_compile_regex(value).map_or(false, |re| re.is_match(dom_low)),
         2 => {
             dom_low == value
                 || (dom_low.len() > value.len()


### PR DESCRIPTION
Проблема: parse_domain_and_match вызывается на каждую domain-entry в каждой категории geo-файла. Для domain_type=1 каждый вызов компилировал Regex::new(value) заново

Решение: глобальный static REGEX_CACHE: LazyLock<RwLock<HashMap<...>>>. Первый раз паттерн виден, компилируется и кладётся в map. Все последующие вызовы берут готовый Arc<Regex> через read-lock. Паттерны в geo-файле статичны, кэш заполняется при первых запросах и дальше только читается.