### PR TITLE
fix(connections): cap closedMap at 1000 entries

### DIFF
--- a/frontend/src/components/configuration/mihomo/Connections.tsx
+++ b/frontend/src/components/configuration/mihomo/Connections.tsx
@@ -93,6 +93,8 @@ let sourceNameRetryTimer: ReturnType<typeof setTimeout> | null = null
 let sourceNameRequest: Promise<void> | null = null
 const useSourceNameStore = create<{ version: number }>(() => ({ version: 0 }))
 
+const MAX_CLOSED_CONNECTIONS = 500
+
 subscribeConnections((connections) => {
   const newMap = toMap(connections)
   const { map: prevMap, closedMap: prevClosed } = useConnectionsStore.getState()
@@ -101,6 +103,15 @@ subscribeConnections((connections) => {
     if (!newMap.has(id) && !prevClosed.has(id)) {
       if (nextClosed === prevClosed) nextClosed = new Map(prevClosed)
       nextClosed.set(id, conn)
+    }
+  }
+  if (nextClosed !== prevClosed && nextClosed.size > MAX_CLOSED_CONNECTIONS) {
+    const excess = nextClosed.size - MAX_CLOSED_CONNECTIONS
+    const iter = nextClosed.keys()
+    for (let i = 0; i < excess; i++) {
+      const key = iter.next().value
+      if (key === undefined) break
+      nextClosed.delete(key)
     }
   }
   useConnectionsStore.setState({ map: newMap, closedMap: nextClosed })

--- a/frontend/src/components/configuration/mihomo/Connections.tsx
+++ b/frontend/src/components/configuration/mihomo/Connections.tsx
@@ -93,7 +93,7 @@ let sourceNameRetryTimer: ReturnType<typeof setTimeout> | null = null
 let sourceNameRequest: Promise<void> | null = null
 const useSourceNameStore = create<{ version: number }>(() => ({ version: 0 }))
 
-const MAX_CLOSED_CONNECTIONS = 500
+const MAX_CLOSED_CONNECTIONS = 1000
 
 subscribeConnections((connections) => {
   const newMap = toMap(connections)


### PR DESCRIPTION
Закрытые соединения накапливаются без ограничений. 
Вытесняем старые записи (по порядку вставки через Map.keys()) при превышении 500.