### PR TITLE
fix(websocket): bound log watcher mpsc channel

### DIFF
--- a/backend/src/websocket.rs
+++ b/backend/src/websocket.rs
@@ -122,12 +122,12 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
         }
         let tx = state.log_tx.clone();
         let handle = tokio::spawn(async move {
-            let (mpsc_tx, mut mpsc_rx) = tokio::sync::mpsc::unbounded_channel();
+            let (mpsc_tx, mut mpsc_rx) = tokio::sync::mpsc::channel::<String>(32);
             let mut watcher = notify::recommended_watcher(move |res: Result<notify::Event, _>| {
                 if let Ok(e) = res {
                     if e.kind.is_modify() {
                         for path in e.paths {
-                            let _ = mpsc_tx.send(path.to_string_lossy().to_string());
+                            let _ = mpsc_tx.try_send(path.to_string_lossy().to_string());
                         }
                     }
                 }


### PR DESCRIPTION
`unbounded_channel` в log-watcher растёт без ограничений при активном access-логе mihomo. Заменил на `channel(32)` + `try_send`; потеря событий ни на что не влияет. Следующее чтение продолжит с offset.
