### PR TITLE
perf(version): cache core version strings with 60s TTL

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -150,6 +150,7 @@ async fn main() {
         geo_cache,
         log_tx: log_tx_arc,
         log_watcher: Arc::new(tokio::sync::Mutex::new(None)),
+        version_cache: Arc::new(RwLock::new(std::collections::HashMap::new())),
         debug,
     };
     version::start_update_checker(state.clone());

--- a/backend/src/types.rs
+++ b/backend/src/types.rs
@@ -95,6 +95,8 @@ pub fn access_log_path() -> String {
     XRAY_LOG_PATHS.read().unwrap().access.clone()
 }
 
+pub type VersionCache = std::collections::HashMap<String, (Option<String>, Instant)>;
+
 #[derive(Clone)]
 pub struct AppState {
     pub core: Arc<RwLock<CoreInfo>>,
@@ -105,6 +107,7 @@ pub struct AppState {
     pub geo_cache: Arc<RwLock<GeoCache>>,
     pub log_tx: Arc<broadcast::Sender<String>>,
     pub log_watcher: Arc<Mutex<Option<AbortHandle>>>,
+    pub version_cache: Arc<RwLock<VersionCache>>,
     pub debug: bool,
 }
 

--- a/backend/src/updater.rs
+++ b/backend/src/updater.rs
@@ -623,6 +623,7 @@ pub async fn post_update(
         *c = None;
     }
     *state.update_checker.last_core_toast.write().unwrap() = None;
+    crate::version::invalidate_version_cache(&state);
 
     response(true, None)
 }

--- a/backend/src/version.rs
+++ b/backend/src/version.rs
@@ -35,6 +35,31 @@ pub async fn get_local_core_version(core: &str) -> Option<String> {
     })
 }
 
+const VERSION_CACHE_TTL: Duration = Duration::from_secs(60);
+
+pub async fn get_local_core_version_cached(state: &AppState, core: &str) -> Option<String> {
+    if let Some(cached) = {
+        let cache = state.version_cache.read().unwrap();
+        cache
+            .get(core)
+            .filter(|(_, ts)| ts.elapsed() < VERSION_CACHE_TTL)
+            .map(|(v, _)| v.clone())
+    } {
+        return cached;
+    }
+    let ver = get_local_core_version(core).await;
+    state
+        .version_cache
+        .write()
+        .unwrap()
+        .insert(core.to_string(), (ver.clone(), Instant::now()));
+    ver
+}
+
+pub fn invalidate_version_cache(state: &AppState) {
+    state.version_cache.write().unwrap().clear();
+}
+
 pub async fn version_handler(State(state): State<AppState>) -> impl IntoResponse {
     let check = |outdated, last: &std::sync::RwLock<Option<Instant>>| {
         outdated && {
@@ -54,8 +79,8 @@ pub async fn version_handler(State(state): State<AppState>) -> impl IntoResponse
     );
 
     let (xray_version, mihomo_version) = tokio::join!(
-        get_local_core_version("xray"),
-        get_local_core_version("mihomo")
+        get_local_core_version_cached(&state, "xray"),
+        get_local_core_version_cached(&state, "mihomo")
     );
 
     let mut core_versions = serde_json::Map::new();


### PR DESCRIPTION
Каждый запрос `/api/version` форкает оба бинаря. Fork на MIPS — 50–100 мс. Кэшировать результаты в `AppState`; инвалидировать после успешного `updater::install_core`.
