### PR TITLE
fix(clash): cap clash proxy body at 16 MB

### DIFF
--- a/backend/src/clash.rs
+++ b/backend/src/clash.rs
@@ -53,7 +53,8 @@ pub async fn proxy_http(
             Err(e) => return make_bad_gateway(e),
         };
 
-    let body_bytes = match to_bytes(body, usize::MAX).await {
+    const CLASH_BODY_LIMIT: usize = 16 * 1024 * 1024;
+    let body_bytes = match to_bytes(body, CLASH_BODY_LIMIT).await {
         Ok(b) => b,
         Err(e) => return make_bad_gateway(e.to_string()),
     };


### PR DESCRIPTION
`to_bytes(body, usize::MAX)` буферизует всё тело запроса в RAM. На роутере с 128 MB один POST в 100 MB вызывает OOM. Ограничить 16 MB — достаточно для любого clash API.
