### PR TITLE
perf(updater): shrink default download buffer to 5 MB

### DIFF
--- a/backend/src/updater.rs
+++ b/backend/src/updater.rs
@@ -133,7 +133,7 @@ async fn download(
         let mut buf = if is_disk {
             Vec::new()
         } else {
-            Vec::with_capacity(if size > 0 { size } else { 64 * 1024 })
+            Vec::with_capacity(if size > 0 { size } else { 5 * 1024 * 1024 })
         };
 
         loop {

--- a/backend/src/updater.rs
+++ b/backend/src/updater.rs
@@ -133,7 +133,7 @@ async fn download(
         let mut buf = if is_disk {
             Vec::new()
         } else {
-            Vec::with_capacity(if size > 0 { size } else { 15 * 1024 * 1024 })
+            Vec::with_capacity(if size > 0 { size } else { 64 * 1024 })
         };
 
         loop {


### PR DESCRIPTION
При отсутствии `Content-Length` резервируется 15 MB сразу. Бинарь в 2 MB тратит 13 MB впустую. Дефолт: `64 * 1024`; аллокатор растёт экспоненциально по мере необходимости.
