### PR TITLE
fix(version): сохранять JoinHandle фоновой задачи проверки версий в AppState

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -150,6 +150,7 @@ async fn main() {
         geo_cache,
         log_tx: log_tx_arc,
         log_watcher: Arc::new(tokio::sync::Mutex::new(None)),
+        update_checker_task: Arc::new(tokio::sync::Mutex::new(None)),
         debug,
     };
     version::start_update_checker(state.clone());

--- a/backend/src/types.rs
+++ b/backend/src/types.rs
@@ -105,6 +105,7 @@ pub struct AppState {
     pub geo_cache: Arc<RwLock<GeoCache>>,
     pub log_tx: Arc<broadcast::Sender<String>>,
     pub log_watcher: Arc<Mutex<Option<AbortHandle>>>,
+    pub update_checker_task: Arc<Mutex<Option<AbortHandle>>>,
     pub debug: bool,
 }
 

--- a/backend/src/version.rs
+++ b/backend/src/version.rs
@@ -75,7 +75,8 @@ pub async fn version_handler(State(state): State<AppState>) -> impl IntoResponse
 }
 
 pub fn start_update_checker(state: AppState) {
-    tokio::spawn(async move {
+    let task_slot = state.update_checker_task.clone();
+    let handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(300));
         loop {
             interval.tick().await;
@@ -130,6 +131,9 @@ pub fn start_update_checker(state: AppState) {
                 }
             }
         }
+    });
+    tokio::spawn(async move {
+        *task_slot.lock().await = Some(handle.abort_handle());
     });
 }
 


### PR DESCRIPTION
`tokio::spawn` в `version.rs:78` выбрасывает handle. Задачу невозможно остановить при shutdown. 
Решение: Хранить `JoinHandle` в `AppState` для корректного завершения при добавлении SIGTERM-обработчика.
