### PR TITLE
fix(log): ограничил DOM лога 1000 строк при auto-scroll

### DIFF
--- a/frontend/src/components/log/LogPanel.tsx
+++ b/frontend/src/components/log/LogPanel.tsx
@@ -12,6 +12,7 @@ import { useWebSocket } from '../../lib/websocket'
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '../ui/input-group'
 
 const LOG_FILES = ['error.log', 'access.log']
+const MAX_LINES = 2000
 
 export function LogPanel() {
   const timezone = useSettings((s) => s.timezone)
@@ -44,32 +45,50 @@ export function LogPanel() {
     if (el) el.scrollTop = el.scrollHeight
   }, [])
 
+  const trimToCap = useCallback(() => {
+    const el = logRef.current
+    if (!el) return
+    const overflow = linesRef.current.length - MAX_LINES
+    if (overflow <= 0) return
+    linesRef.current.splice(0, overflow)
+    for (let i = 0; i < overflow && el.firstChild; i++) {
+      el.removeChild(el.firstChild)
+    }
+  }, [])
+
   const renderAll = useCallback((lines: string[]) => {
     const el = logRef.current
     if (!el) return
 
-    linesRef.current = lines
-    const hasLines = lines.length > 0
+    const capped = lines.length > MAX_LINES ? lines.slice(lines.length - MAX_LINES) : lines
+    linesRef.current = capped
+    const hasLines = capped.length > 0
 
     setIsEmpty(!hasLines)
-    el.innerHTML = hasLines ? lines.join('') : ''
+    el.innerHTML = hasLines ? capped.join('') : ''
 
     if (hasLines && autoScrollRef.current) {
       el.scrollTop = el.scrollHeight
     }
   }, [])
 
-  const appendLines = useCallback((newLines: string[]) => {
-    if (newLines.length === 0) return
-    const el = logRef.current
-    if (!el) return
+  const appendLines = useCallback(
+    (newLines: string[]) => {
+      if (newLines.length === 0) return
+      const el = logRef.current
+      if (!el) return
 
-    setIsEmpty(false)
-    linesRef.current.push(...newLines)
-    el.insertAdjacentHTML('beforeend', newLines.join(''))
+      setIsEmpty(false)
+      linesRef.current.push(...newLines)
+      el.insertAdjacentHTML('beforeend', newLines.join(''))
 
-    if (autoScrollRef.current) el.scrollTop = el.scrollHeight
-  }, [])
+      if (autoScrollRef.current) {
+        trimToCap()
+        el.scrollTop = el.scrollHeight
+      }
+    },
+    [trimToCap]
+  )
 
   const handleMessage = useCallback(
     (data: WsMessage) => {
@@ -132,6 +151,7 @@ export function LogPanel() {
   function handleScrollToBottom() {
     autoScrollRef.current = true
     setShowScrollBtn(false)
+    trimToCap()
     scrollToBottom()
   }
 

--- a/frontend/src/components/log/LogPanel.tsx
+++ b/frontend/src/components/log/LogPanel.tsx
@@ -12,7 +12,7 @@ import { useWebSocket } from '../../lib/websocket'
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '../ui/input-group'
 
 const LOG_FILES = ['error.log', 'access.log']
-const MAX_LINES = 2000
+const MAX_LINES = 1000
 
 export function LogPanel() {
   const timezone = useSettings((s) => s.timezone)


### PR DESCRIPTION
## Проблема

`LogPanel` хранит строки в `linesRef.current` + DOM через `innerHTML`/
`insertAdjacentHTML` без виртуализации и cap. На длинных сессиях DOM растёт
неограниченно, а это значит что на слабом железе вкладка деградирует.

Предыдущий PR #33 (cap 2000) был отклонён из-за регрессии: обрезка top
строк ломала scroll-позицию, когда пользователь читал историю
(issue zxc-rv/XKeen-UI#11).

## Решение

Применять cap **только** когда `autoScrollRef.current === true` (юзер у дна).
Логика:

- `appendLines`: после push, если auto-scroll включён и длина > 2000 —
  отрезать `overflow` строк с начала `linesRef` и удалить столько же первых
  дочерних узлов из DOM. 1:1 mapping (backend шлёт 1 line = 1 root `<div>`).
- `renderAll`: при initial/filtered с большим payload оставлять последние
  2000 строк (на коротких строках бэк-лимит 128 KB даёт тысячи).
- `handleScrollToBottom`: при возврате к низу применить trim и это гасит
  накопленный «leak» от чтения сверху.

## Тест

1. Открыть лог, дождаться flood ≥2000 строк → `logRef.children.length` ≤ 2000.
2. Скроллить вверх → новые строки добавляются ниже, первая видимая строка
   не сдвигается.
3. Кнопка «вниз» → trim сработал, DOM ≤ 2000.