### PR TITLE
fix(updater): refactor EXDEV fallback

### DIFF
--- a/backend/src/controller.rs
+++ b/backend/src/controller.rs
@@ -84,7 +84,7 @@ async fn resolve_init_file(state: &AppState) -> Result<String, String> {
     Ok(new_path)
 }
 
-async fn run_init_command(state: &AppState, args: &[&str]) -> Result<(), String> {
+pub async fn run_init_command(state: &AppState, args: &[&str]) -> Result<(), String> {
     let path = resolve_init_file(state).await?;
     let result = if let Ok(f) = std::fs::OpenOptions::new()
         .create(true)

--- a/backend/src/updater.rs
+++ b/backend/src/updater.rs
@@ -591,11 +591,9 @@ pub async fn post_update(
             "WARN",
             "Атомарная замена не удалась, фолбек на копирование...".into(),
         );
-        let init = state.init_file.read().unwrap().clone();
         if run {
-            if let Some(ref init) = init {
-                _ = Command::new(init).arg("stop").status().await;
-            }
+            log("INFO", "Остановка XKeen...".into());
+            _ = crate::controller::run_init_command(&state, &["stop"]).await;
         }
         if let Err(e) = fs::copy(&source, &target).await {
             return response(false, Some(format!("Ошибка установки: {}", e)));
@@ -603,10 +601,8 @@ pub async fn post_update(
         _ = fs::remove_file(&source).await;
         _ = fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).await;
         if run {
-            if let Some(ref init) = init {
-                log("INFO", "Запуск XKeen...".into());
-                _ = Command::new(init).arg("start").status().await;
-            }
+            log("INFO", "Запуск XKeen...".into());
+            _ = crate::controller::run_init_command(&state, &["start", "on"]).await;
         }
     }
 

--- a/backend/src/updater.rs
+++ b/backend/src/updater.rs
@@ -605,7 +605,7 @@ pub async fn post_update(
         if run {
             if let Some(ref init) = init {
                 log("INFO", "Запуск XKeen...".into());
-                _ = Command::new(init).arg("start").status();
+                _ = Command::new(init).arg("start").status().await;
             }
         }
     }


### PR DESCRIPTION
## Проблема

`backend/src/updater.rs:608` запускает init-скрипт после fallback-копирования
бинарника без `.await`:

```rust
_ = Command::new(init).arg("start").status();

tokio::process::Command::status() возвращает Future. Без .await
он сразу дропается, init не вызывается. После апдейта ядро остаётся
остановленным, нужен ручной S99XKEEN start или перезагрузка роутера.

Соседний stop (строка 597) корректно использует .await - это
очевидная опечатка.

Когда воспроизводится

Fallback-ветка срабатывает при EXDEV от fs::rename (исходник и
target на разных файловых системах, например, tmpfs vs ext4/flash).

Тест

Подменить init на sh -c 'echo "$@" >> /tmp/init.log', спровоцировать
EXDEV (положить tmp_dir и /opt/sbin/ на разные fs), обновить ядро.
В /tmp/init.log должна появиться строка start. Без fix строки не будет.