### PR TITLE
fix(config): сериализовал запись APP_CONFIG + atomic rename

### DIFF
--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -357,6 +357,7 @@ async fn update_auth(state: &AppState, modify: impl FnOnce(&mut crate::types::Au
 }
 
 async fn save_auth_to_config(state: &AppState) {
+    let _guard = state.app_config_lock.lock().await;
     let auth = state.settings.read().unwrap().auth.clone();
     let mut file_json: serde_json::Value = tokio::fs::read_to_string(APP_CONFIG)
         .await
@@ -364,9 +365,9 @@ async fn save_auth_to_config(state: &AppState) {
         .and_then(|c| serde_json::from_str(&c).ok())
         .unwrap_or(serde_json::json!({}));
     file_json["auth"] = serde_json::to_value(auth).unwrap();
-    let _ = tokio::fs::write(
-        APP_CONFIG,
-        serde_json::to_string_pretty(&file_json).unwrap(),
-    )
-    .await;
+    let serialized = serde_json::to_string_pretty(&file_json).unwrap();
+    let tmp = format!("{}.tmp", APP_CONFIG);
+    if tokio::fs::write(&tmp, &serialized).await.is_ok() {
+        let _ = tokio::fs::rename(&tmp, APP_CONFIG).await;
+    }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -150,6 +150,7 @@ async fn main() {
         geo_cache,
         log_tx: log_tx_arc,
         log_watcher: Arc::new(tokio::sync::Mutex::new(None)),
+        app_config_lock: Arc::new(tokio::sync::Mutex::new(())),
         debug,
     };
     version::start_update_checker(state.clone());

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -3,7 +3,6 @@ use axum::{
     extract::State,
     response::{IntoResponse, Json},
 };
-use std::fs;
 
 pub async fn get_settings(State(state): State<AppState>) -> impl IntoResponse {
     let s = state.settings.read().unwrap();
@@ -16,7 +15,9 @@ pub async fn patch_settings(
     State(state): State<AppState>,
     Json(patch): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    let mut file_json = fs::read_to_string(APP_CONFIG)
+    let _guard = state.app_config_lock.lock().await;
+    let mut file_json = tokio::fs::read_to_string(APP_CONFIG)
+        .await
         .ok()
         .and_then(|c| serde_json::from_str(&c).ok())
         .unwrap_or(serde_json::json!({}));
@@ -62,11 +63,13 @@ pub async fn patch_settings(
 
     *state.settings.write().unwrap() = settings;
 
-    match fs::write(
-        APP_CONFIG,
-        serde_json::to_string_pretty(&file_json).unwrap(),
-    ) {
-        Ok(_) => Json(serde_json::json!({"success": true})),
+    let serialized = serde_json::to_string_pretty(&file_json).unwrap();
+    let tmp = format!("{}.tmp", APP_CONFIG);
+    match tokio::fs::write(&tmp, &serialized).await {
+        Ok(_) => match tokio::fs::rename(&tmp, APP_CONFIG).await {
+            Ok(_) => Json(serde_json::json!({"success": true})),
+            Err(e) => Json(serde_json::json!({"success": false, "error": e.to_string()})),
+        },
         Err(e) => Json(serde_json::json!({"success": false, "error": e.to_string()})),
     }
 }

--- a/backend/src/types.rs
+++ b/backend/src/types.rs
@@ -105,6 +105,7 @@ pub struct AppState {
     pub geo_cache: Arc<RwLock<GeoCache>>,
     pub log_tx: Arc<broadcast::Sender<String>>,
     pub log_watcher: Arc<Mutex<Option<AbortHandle>>>,
+    pub app_config_lock: Arc<Mutex<()>>,
     pub debug: bool,
 }
 


### PR DESCRIPTION
## Проблема

`save_auth_to_config` (`backend/src/auth.rs`) и `patch_settings`
(`backend/src/settings.rs`) оба делают read-modify-write
`/opt/etc/xkeen/xkeen-ui.json` без shared lock:

1. **Race / lost update.** Параллельный логин и PATCH settings:
   оба читают исходный JSON, оба применяют свои изменения,
   последний пишущий затирает чужое поле. Конкретно: свежий `session_id`
   из логина теряется, либо `gui.*` settings откатываются.
2. **Не-атомарная запись.** `tokio::fs::write`/`std::fs::write` пишет
   поверх. При kill -9 / power loss посередине файл остаётся
   усечённым → на следующем старте `Auth` теряется, пользователь
   вылетает к экрану setup.
3. Минор: `patch_settings`: async handler с блокирующим `std::fs`.

## Решение

- `AppState.app_config_lock: Arc<tokio::sync::Mutex<()>>`.
- Оба handler-а берут lock на всё RMW.
- Запись через `{APP_CONFIG}.tmp` → `tokio::fs::rename`. Rename внутри
  одной fs атомарен на ext4/f2fs.
- `settings.rs` целиком на `tokio::fs::*` для согласованности.

Reset-password CLI-путь (`main.rs:59-76`) с runtime не пересекается это
отдельный процесс, lock не нужен.

## Тест

```sh
# 20 параллельных login + curl PATCH в цикле
wrk -c 20 -t 4 -d 10s -s post_login.lua http://localhost:1000 &
while true; do curl -X PATCH http://localhost:1000/api/settings \
  -d '{"gui":{"routing":true}}'; done

После теста: xkeen-ui.json валидный JSON, нет потерянных полей.
Прерывание процесса в момент записи = файл валиден (либо старая,
либо новая версия).