### PR TITLE
fix(config): не выставлять running при failed restart

### DIFF
--- a/backend/src/controller.rs
+++ b/backend/src/controller.rs
@@ -136,10 +136,11 @@ pub fn get_pid(name: &str) -> Vec<i32> {
         .collect()
 }
 
-pub async fn soft_restart(core: &str) {
+pub async fn soft_restart(core: &str) -> Result<(), String> {
     for pid in get_pid(core) {
         _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
     }
+
     let mut cmd = Command::new(core);
     match core {
         "mihomo" => {
@@ -152,11 +153,8 @@ pub async fn soft_restart(core: &str) {
             ]);
         }
     }
-    let lim = if cfg!(target_arch = "aarch64") {
-        40000
-    } else {
-        10000
-    };
+
+    let lim = if cfg!(target_arch = "aarch64") { 40000 } else { 10000 };
     unsafe {
         cmd.pre_exec(move || {
             setsid()?;
@@ -165,6 +163,7 @@ pub async fn soft_restart(core: &str) {
             Ok(())
         });
     }
+
     if let Ok(f) = std::fs::File::options()
         .append(true)
         .create(true)
@@ -172,11 +171,21 @@ pub async fn soft_restart(core: &str) {
     {
         cmd.stdout(f.try_clone().unwrap()).stderr(f);
     }
-    if let Ok(mut c) = cmd.spawn() {
-        tokio::spawn(async move {
-            _ = c.wait().await;
-        });
+
+    let mut child = cmd.spawn().map_err(|e| e.to_string())?;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    match child.try_wait() {
+        Ok(Some(status)) if !status.success() => {
+            return Err(format!("не удалось перезапустить {}: {}", core, status));
+        }
+        _ => {
+            tokio::spawn(async move {
+                _ = child.wait().await;
+            });
+        }
     }
+
+    Ok(())
 }
 
 pub async fn get_control(State(state): State<AppState>) -> impl IntoResponse {
@@ -331,7 +340,15 @@ pub async fn post_control(
                 });
             }
         }
-        "softRestart" => soft_restart(&req.core).await,
+        "softRestart" => {
+            if let Err(e) = soft_restart(&req.core).await {
+                return Json(ApiResponse {
+                    success: false,
+                    error: Some(e),
+                    data: None,
+                });
+            }
+        }
         a if ["start", "stop", "hardRestart"].contains(&a) => {
             let arg = match a {
                 "start" => "start",

--- a/frontend/src/components/configuration/ConfigPanel.tsx
+++ b/frontend/src/components/configuration/ConfigPanel.tsx
@@ -523,7 +523,7 @@ export function ConfigPanel({ onOpenImport, onOpenTemplate, onOpenGeoScan, onRef
       core: currentCore,
     })
     showToast(r?.success ? 'Изменения применены' : `Ошибка: ${r?.error}`, r?.success ? 'success' : 'error')
-    dispatch({ type: 'SET_SERVICE_STATUS', status: 'running' })
+    dispatch({ type: 'SET_SERVICE_STATUS', status: r?.success ? 'running' : 'stopped' })
     if (r?.success) {
       syncClashApiPort(200)
     }


### PR DESCRIPTION
## Проблема

`ConfigPanel.saveAndApply` (`frontend/src/components/configuration/
ConfigPanel.tsx:526`) после control-запроса:

```ts
showToast(r?.success ? '...' : `Ошибка: ${r?.error}`, ...)
dispatch({ type: 'SET_SERVICE_STATUS', status: 'running' })

Статус running выставляется безусловно, в том числе когда backend
вернул success: false. StatusBar показывает «Сервис запущен», пока
ядро на самом деле упало / не стартует. До следующего автополла
checkStatus (~15с) пользователь видит ложно-зелёный индикатор и думает,
что всё применилось.

Решение

status: r?.success ? 'running' : 'stopped' это тот же паттерн, что
уже используется в:
- components/status/StatusBar.tsx:52, 70 (старт/стоп кнопки)
- App.tsx:129 (poll checkStatus)

Тест

Сохранить и применить заведомо ломаный конфиг (outbounds: invalid) →
toast «Ошибка», StatusBar показывает «Остановлен», не «Запущен».