### PR TITLE
add health check to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,8 +41,10 @@ spinner() {
 }
 
 get_arch() {
-  local cpuinfo=$(grep -i 'model name' /proc/cpuinfo | sed -e 's/.*: //i' | tr '[:upper:]' '[:lower:]')
+  local hw_id
+  hw_id=$(curl -sf http://localhost:79/rci/show/version | jq -r '.hw_id | ascii_upcase')
 
+  local cpuinfo=$(grep -i 'model name' /proc/cpuinfo | sed -e 's/.*: //i' | tr '[:upper:]' '[:lower:]')
   case "$(uname -m | tr '[:upper:]' '[:lower:]')" in
     *'armv8'* | *'aarch64'* | *'cortex-a'* ) ARCH='arm64-v8a';;
     *'mipsle'* | *'mips 1004'* | *'mips 34'* | *'mips 24'* ) ARCH='mips32le';;
@@ -59,23 +61,24 @@ get_arch() {
         fi
         ;;
   esac
-
   if [[ "$ARCH" = mips32 || "$ARCH" = mips64 ]]; then
     [ -f /opt/bin/lscpu ] || opkg install lscpu &>/dev/null
     local lscpu_output="$(lscpu 2>/dev/null | tr '[:upper:]' '[:lower:]')"
     echo "$lscpu_output" | grep -q "little endian" && ARCH="${ARCH}le"
   fi
-
   if [[ "$ARCH" == "mips32le" ]]; then
-    [ -f /lib/ld-musl-mipsel-sf.so.1 ] || ARCH="${ARCH}-gnu"
+    case "$hw_id" in
+      KN-1710|KN-1711|KN-1713) ARCH="${ARCH}-gnu";;
+      *) [ -f /lib/ld-musl-mipsel-sf.so.1 ] || ARCH="${ARCH}-gnu";;
+    esac
   fi
 }
 
-verify_binary() {
+healthcheck() {
   timeout 5 "$XKEENUI_BIN" -v >/dev/null 2>&1
 }
 
-_fetch_arch_bin() {
+_fetch_binary() {
   local download_url="$1"
   local bin_name="xkeen-ui-$ARCH"
   local msg
@@ -112,16 +115,16 @@ download_files() {
     download_url="$base_url/download/$beta_tag"
   fi
 
-  _fetch_arch_bin "$download_url"
+  _fetch_binary "$download_url"
 
-  if [ "$ARCH" = "mips32le" ] && ! verify_binary; then
-    printf "${YELLOW}\n Бинарник mips32le несовместим с системой, переключение на mips32le-gnu...\n${NC}"
+  if [ "$ARCH" = "mips32le" ] && ! healthcheck; then
+    printf "${YELLOW}\n Исполняемый файл mips32le несовместим с системой, фолбэк на gnu...\n${NC}"
     ARCH="mips32le-gnu"
     LOCAL=false
     [ -f "/opt/tmp/xkeen-ui-$ARCH" ] && LOCAL=true
-    _fetch_arch_bin "$download_url"
-    if ! verify_binary; then
-      printf "${RED_BOLD}\n Бинарник $ARCH также не запускается. Прерывание.${NCN}"
+    _fetch_binary "$download_url"
+    if ! healthcheck; then
+      printf "${RED_BOLD}\n Исполняемый файл $ARCH также не запускается. Прерывание.${NCN}"
       exit 1
     fi
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -71,10 +71,32 @@ get_arch() {
   fi
 }
 
+verify_binary() {
+  timeout 5 "$XKEENUI_BIN" -v >/dev/null 2>&1
+}
+
+_fetch_arch_bin() {
+  local download_url="$1"
+  local bin_name="xkeen-ui-$ARCH"
+  local msg
+
+  if [ "$LOCAL" = true ] && [ -f "/opt/tmp/$bin_name" ]; then
+    msg="Локальная установка бинарника..."
+    ( set -e; mv "/opt/tmp/$bin_name" $XKEENUI_BIN && chmod +x $XKEENUI_BIN ) &
+  else
+    msg="Загрузка бинарника..."
+    ( set -e; curl -Lsfo $XKEENUI_BIN $download_url/$bin_name && chmod +x $XKEENUI_BIN ) &
+  fi
+
+  if ! spinner $! "$msg"; then
+    printf "${RED_BOLD}\n Не удалось получить бинарник $bin_name.${NCN}"
+    exit 1
+  fi
+}
+
 download_files() {
   local base_url="https://github.com/zxc-rv/XKeen-UI/releases"
   local download_url="$base_url/latest/download"
-  local bin_name="xkeen-ui-$ARCH"
 
   if [ "$BETA" = true ]; then
     local beta_tag="/tmp/xkeen_beta"
@@ -90,16 +112,16 @@ download_files() {
     download_url="$base_url/download/$beta_tag"
   fi
 
-  if [ "$LOCAL" = true ] && [ -f "/opt/tmp/$bin_name" ]; then
-    ( set -e; mv "/opt/tmp/$bin_name" $XKEENUI_BIN && chmod +x $XKEENUI_BIN ) &
-    if ! spinner $! "Локальная установка бинарника..."; then
-      printf "${RED_BOLD}\n Не удалось переместить бинарник.${NCN}"
-      exit 1
-    fi
-  else
-    ( set -e; curl -Lsfo $XKEENUI_BIN $download_url/$bin_name && chmod +x $XKEENUI_BIN ) &
-    if ! spinner $! "Загрузка бинарника..."; then
-      printf "${RED_BOLD}\n Не удалось загрузить бинарник.${NCN}"
+  _fetch_arch_bin "$download_url"
+
+  if [ "$ARCH" = "mips32le" ] && ! verify_binary; then
+    printf "${YELLOW}\n Бинарник mips32le несовместим с системой, переключение на mips32le-gnu...\n${NC}"
+    ARCH="mips32le-gnu"
+    LOCAL=false
+    [ -f "/opt/tmp/xkeen-ui-$ARCH" ] && LOCAL=true
+    _fetch_arch_bin "$download_url"
+    if ! verify_binary; then
+      printf "${RED_BOLD}\n Бинарник $ARCH также не запускается. Прерывание.${NCN}"
       exit 1
     fi
   fi

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,3 +1,24 @@
 # FAQ
 
-_Раздел в разработке._
+## 1. Не удалось запустить XKeen UI"
+
+**Q**: UI не запускается и появляется следующая ошибка
+
+```bash
+xkeen-ui -v
+Error relocating /opt/sbin/xkeen-ui: stat: symbol not found
+Error relocating /opt/sbin/xkeen-ui: pthread_setname_np: symbol not found
+Error relocating /opt/sbin/xkeen-ui: posix_spawnattr_setpgroup: symbol not found
+Error relocating /opt/sbin/xkeen-ui: pthread_getattr_np: symbol not found
+Error relocating /opt/sbin/xkeen-ui: posix_spawnp: symbol not found
+Error relocating /opt/sbin/xkeen-ui: bcmp: symbol not found
+Error relocating /opt/sbin/xkeen-ui: lstat: symbol not found
+Error relocating /opt/sbin/xkeen-ui: clock_gettime: symbol not found
+Error relocating /opt/sbin/xkeen-ui: fstat: symbol not found
+Error relocating /opt/sbin/xkeen-ui: posix_spawn_file_actions_addchdir_np: symbol not found
+Error relocating /opt/sbin/xkeen-ui: waitid: symbol not found
+```
+
+**A**: Понятно, ставьте [версию с припиской «gnu»](https://github.com/zxc-rv/XKeen-UI/releases/tag/v1.0.0).
+Закинуть в `/opt/sbin` с названием `xkeen-ui`
+затем `chmod +x /opt/sbin/xkeen-ui && xkeen-ui --start`


### PR DESCRIPTION
Здесь в этот PR ещё попал коммит про faq - пусть будет так.

## Summary

Fixes #58 — `setup.sh` неправильно выбирает MIPS-бинарник на Keenetic Extra (MT7628) и подобных устройствах с musl-loader, но без полного набора libc-символов.

Pre-check `[ -f /lib/ld-musl-mipsel-sf.so.1 ]` работает только в одну сторону: отсутствие loader-а → нужен gnu, но его наличие не гарантирует символьную совместимость. На MT7628 loader присутствует, а `xkeen-ui-mips32le` падает с `Error relocating ... symbol not found`.

## Changes

- `verify_binary()` — запуск `$XKEENUI_BIN -v` с `timeout 5`, проверка exit code. Любая поломка (relocation, отсутствие символов, segfault) ловится универсально, без хрупкого парсинга stderr.
- `_fetch_arch_bin()` — выделенный helper для download / local mv (DRY между первой попыткой и fallback).
- `download_files()` — после fetch, если `ARCH = mips32le` и verify фейлится: переключение `ARCH=mips32le-gnu`, повторный fetch, повторный verify. Двойной фейл → ясная ошибка и выход.
- Pre-check на loader (lines 69–71) сохранён как fast-path: если loader отсутствует, сразу качаем `-gnu` без лишнего round-trip.

Применяется и к install, и к update — оба используют общий `download_files`.

## Why glibc variant works as fallback

`xkeen-ui-mips32le-gnu` собирается с `RUSTFLAGS=-C target-feature=+crt-static` (`.github/workflows/build-rust.yml`) — статически линкованный glibc. Не зависит от libc на устройстве, работает на любом MIPS-LE с совместимым kernel ABI.

## Test plan

- [ ] **MT7628 / Keenetic Extra**: установка через `curl ... | sh` → видно сообщение «Бинарник mips32le несовместим…» → скачивается `-gnu` → запуск проходит → `/opt/sbin/xkeen-ui -v` печатает версию.
- [ ] **Совместимое mips32le-устройство** (Keenetic Hopper и т.п.): установка без fallback-сообщений, ARCH остаётся `mips32le`.
- [ ] **arm64-v8a / mips32**: поведение не меняется (verify-блок не срабатывает — фильтр `ARCH = mips32le`).
- [ ] **Loader отсутствует**: pre-check переключает на `mips32le-gnu` ДО download, verify не вызывается.
- [ ] **Local mode**: `/opt/tmp/xkeen-ui-mips32le` (битый) + `/opt/tmp/xkeen-ui-mips32le-gnu` (рабочий) → setup пробует локальный mips32le → verify фейлится → локальный gnu подхватывается без сети.
- [ ] **Update path**: пользователь раньше руками поставил `-gnu` workaround → update перепроверяет → оставляет `-gnu` автоматически.