### PR TITLE
fix: reduce Firefox-Windows GPU/memory blowup in panel  On Windows 10…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,19 @@ function useThemeMode(theme: ThemeMode) {
   }, [theme])
 }
 
+// Пауза непрерывных декоративных анимаций при скрытой вкладке (см. globals.css
+// `html.anim-paused`). На Windows Firefox это останавливает ре-растеризацию,
+// которая раздувает пул GPU-текстур пока панель в фоне.
+function usePauseAnimationsWhenHidden() {
+  useEffect(() => {
+    const root = document.documentElement
+    const sync = () => root.classList.toggle('anim-paused', document.hidden)
+    sync()
+    document.addEventListener('visibilitychange', sync)
+    return () => document.removeEventListener('visibilitychange', sync)
+  }, [])
+}
+
 interface ModalManagerProps {
   onSwitchCore: (core: string) => void
   onInstalled: () => void
@@ -450,6 +463,7 @@ export default function App() {
   const theme = useSettings((s) => s.theme)
 
   useThemeMode(theme)
+  usePauseAnimationsWhenHidden()
 
   useEffect(() => {
     fetch('/api/auth/login')

--- a/frontend/src/components/log/LogPanel.tsx
+++ b/frontend/src/components/log/LogPanel.tsx
@@ -85,6 +85,12 @@ export function LogPanel() {
       if (autoScrollRef.current) {
         trimToCap()
         el.scrollTop = el.scrollHeight
+      } else {
+        // Кэпируем массив и DOM даже при скролле вверх, иначе лог растёт
+        // безгранично. Компенсируем scrollTop, чтобы вьюпорт не дёргался.
+        const heightBefore = el.scrollHeight
+        trimToCap()
+        el.scrollTop -= heightBefore - el.scrollHeight
       }
     },
     [trimToCap]
@@ -395,7 +401,7 @@ export function LogPanel() {
               <Button
                 variant="outline"
                 size="icon-sm"
-                className="bg-background/80 absolute right-8 bottom-8 z-10 shadow-lg backdrop-blur!"
+                className="bg-background absolute right-8 bottom-8 z-10 shadow-lg"
                 onClick={handleScrollToBottom}
               >
                 <IconChevronDown size={14} />

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -21,7 +21,7 @@ function AlertDialogOverlay({ className, ...props }: React.ComponentProps<typeof
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        'data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-50 bg-black/10 duration-200 supports-backdrop-filter:backdrop-blur-xs',
+        'data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-50 bg-[#020817]/60 duration-200',
         className
       )}
       {...props}

--- a/frontend/src/components/ui/shine-border.tsx
+++ b/frontend/src/components/ui/shine-border.tsx
@@ -44,7 +44,7 @@ export function ShineBorder({ borderWidth = 1, duration = 14, shineColor = '#000
         } as React.CSSProperties
       }
       className={cn(
-        'motion-safe:animate-shine pointer-events-none absolute inset-0 size-full rounded-[inherit] will-change-[background-position]',
+        'motion-safe:animate-shine pointer-events-none absolute inset-0 size-full rounded-[inherit]',
         className
       )}
       {...props}

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -198,6 +198,16 @@
       background-position: 0% 0%;
     }
   }
+  /* Перенаправляем animate-in/animate-out на filter-free keyframes (xk-enter/
+     xk-exit, см. ниже). Значение 1:1 повторяет tw-animate-css, меняется только
+     имя keyframe. Переопределение переменной (last-wins) надёжнее override
+     одноимённых @keyframes, которые Lightning CSS сливает. */
+  --animate-in: xk-enter var(--tw-animation-duration, var(--tw-duration, 0.15s)) var(--tw-ease, ease)
+    var(--tw-animation-delay, 0s) var(--tw-animation-iteration-count, 1) var(--tw-animation-direction, normal)
+    var(--tw-animation-fill-mode, none);
+  --animate-out: xk-exit var(--tw-animation-duration, var(--tw-duration, 0.15s)) var(--tw-ease, ease)
+    var(--tw-animation-delay, 0s) var(--tw-animation-iteration-count, 1) var(--tw-animation-direction, normal)
+    var(--tw-animation-fill-mode, none);
 }
 
 @layer base {
@@ -287,11 +297,11 @@
   0%,
   100% {
     opacity: 0.35;
-    transform: translateZ(0) scale(1);
+    transform: scale(1);
   }
   50% {
     opacity: 0.7;
-    transform: translateZ(0) scale(1.02);
+    transform: scale(1.02);
   }
 }
 
@@ -310,7 +320,41 @@
   opacity: 0.35;
   animation: dark-glow 2.4s ease-in-out infinite;
   pointer-events: none;
-  will-change: opacity, transform;
+}
+
+/* Pause continuous decorative animations when the tab is hidden — на Windows
+   Firefox (WebRender + ANGLE/D3D11) непрерывная ре-растеризация раздувает пул
+   текстур GPU-процесса. Класс anim-paused тогглится в App.tsx по visibilitychange. */
+html.anim-paused .animate-aurora,
+html.anim-paused .animate-shine,
+html.anim-paused .animate-ping,
+html.anim-paused .animate-dark-glow::after {
+  animation-play-state: paused;
+}
+
+/* Drop-in replacement for tw-animate-css enter/exit keyframes WITHOUT
+   `filter: blur(0)`. Даже blur(0) заставляет Firefox-Windows выделять
+   полноэкранную filter-поверхность на каждое открытие модалки/поповера.
+   Уникальные имена (xk-*) — иначе Lightning CSS сливает одноимённые
+   keyframes и blur из библиотечной версии возвращается. Утилиты
+   blur-in/blur-out не используются, поэтому фильтр убран целиком.
+   Редирект на эти keyframes — через override --animate-in/--animate-out
+   в @theme выше. */
+@keyframes xk-enter {
+  from {
+    opacity: var(--tw-enter-opacity, 1);
+    transform: translate3d(var(--tw-enter-translate-x, 0), var(--tw-enter-translate-y, 0), 0)
+      scale3d(var(--tw-enter-scale, 1), var(--tw-enter-scale, 1), var(--tw-enter-scale, 1))
+      rotate(var(--tw-enter-rotate, 0));
+  }
+}
+@keyframes xk-exit {
+  to {
+    opacity: var(--tw-exit-opacity, 1);
+    transform: translate3d(var(--tw-exit-translate-x, 0), var(--tw-exit-translate-y, 0), 0)
+      scale3d(var(--tw-exit-scale, 1), var(--tw-exit-scale, 1), var(--tw-exit-scale, 1))
+      rotate(var(--tw-exit-rotate, 0));
+  }
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -394,6 +394,21 @@ export const useProxiesStore = create<ProxiesStore>(() => ({
 
 const iconCache = new Map<string, string>()
 const fetchingIcons = new Set<string>()
+const ICON_CACHE_CAP = 512
+
+// FIFO-кэп: каждый createObjectURL держит backing-буфер до закрытия страницы
+// (Firefox не освобождает по GC). Вытесняем старейший и revoke'аем его blob.
+function cacheIcon(url: string, blobUrl: string) {
+  iconCache.set(url, blobUrl)
+  if (iconCache.size > ICON_CACHE_CAP) {
+    const oldestKey = iconCache.keys().next().value
+    if (oldestKey !== undefined) {
+      const oldBlob = iconCache.get(oldestKey)
+      if (oldBlob) URL.revokeObjectURL(oldBlob)
+      iconCache.delete(oldestKey)
+    }
+  }
+}
 
 async function preloadIcons(urls: string[]) {
   let updated = false
@@ -404,7 +419,7 @@ async function preloadIcons(urls: string[]) {
       try {
         const res = await fetch(url)
         if (res.ok) {
-          iconCache.set(url, URL.createObjectURL(await res.blob()))
+          cacheIcon(url, URL.createObjectURL(await res.blob()))
           updated = true
         }
       } catch {
@@ -472,4 +487,8 @@ export function syncClashApiPort(delayMs = 0): void {
 // ─── Global tick for timeAgo refresh (every 1s) ────────────────────────────────
 
 export const useNowStore = create<{ tick: number }>(() => ({ tick: 0 }))
-setInterval(() => useNowStore.setState((s) => ({ tick: s.tick + 1 })), 1000)
+// Тикаем только при видимой вкладке: иначе все TimeAgoCell (по строке на
+// соединение) ре-рендерятся 1 Гц даже когда панель в фоне.
+setInterval(() => {
+  if (!document.hidden) useNowStore.setState((s) => ({ tick: s.tick + 1 }))
+}, 1000)


### PR DESCRIPTION
Fix: потребление ОЗУ до 750 МБ в Firefox на Windows

Проблема

При использовании панели в Firefox на Windows 10/11 потребление ОЗУ доходит до ~750 МБ. На Chromium и на Firefox под Linux такого нет.

Причина

Различающий фактор: GPU-композитор. Firefox-Windows работает через WebRender + ANGLE/D3D11, тогда как Firefox-Linux использует нативный GL/EGL, а Chromium собственный композитор. На D3D11 backing stores под перманентно закреплённые слои (will-change), backdrop-filter и mask-поверхности крупные и плохо освобождаются. Постоянно работающие бесконечные анимации (заголовок, рамка статуса) непрерывно ре-растеризуются → пул текстур GPU-процесса раздувается со временем.

Поэтому чисто JS/DOM-механизмы исключены: Gecko одинаков на Linux и Windows, иначе Linux Firefox страдал бы так же.

Изменения

GPU-композиторная гигиена (главное, чинит симптом Win-FF):

- Снят will-change с всегда-смонтированного .animate-dark-glow::after (свечение заголовка) и с ShineBorder больше не закрепляют перманентный GPU-слой. Убран избыточный translateZ(0) из keyframe dark-glow.
- animate-in/animate-out перенаправлены на filter-free keyframes (xk-enter/xk-exit) через override --animate-in/--animate-out. У keyframes enter/exit из tw-animate-css есть filter: blur(0), под который Firefox-Windows выделяет полноэкранную filter-поверхность на каждое открытие модалки/поповера. Override по имени не работает (Lightning CSS сливает одноимённые keyframes, blur возвращается) → редирект через theme-переменную, детерминированно.
- Убран backdrop-filter с full-viewport overlay у AlertDialog (теперь сплошной фон, как у основного Dialog) и с кнопки прокрутки в логе.
- Пауза непрерывных декоративных анимаций при скрытой вкладке через класс html.anim-paused (тоггл по visibilitychange).

Кросс-браузерные утечки памяти:

- LogPanel: лог теперь всегда обрезается до MAX_LINES, в том числе при прокрутке вверх (раньше DOM/массив росли безгранично), с компенсацией scrollTop, чтобы вьюпорт не дёргался.
- store: FIFO-кэп iconCache (512) + revokeObjectURL при вытеснении blob-URL никогда не освобождались и копились весь сеанс.
- store: тик useNowStore только при видимой вкладке снимает 1 Гц ре-рендер-churn всех TimeAgoCell в фоне.

Визуал анимаций сохранён на всех браузерах (снято только закрепление слоёв + пауза в фоне). Бэкенд не затронут. Тесты не добавлялись (их нет, по конвенции проекта).

Не входит в PR

Виртуализация таблицы Connections (@tanstack/react-virtual, новая зависимость + рефактор) отложена. Делать, только если после этих правок память всё ещё высока.

Проверка

- cd frontend && bun run build сборка проходит, TypeScript чист; bun run lint, затронутые файлы без ошибок.
- В собранном бандле: will-change = 0, backdrop-filter = 0, .animate-in → xk-enter без blur, shine-анимация цела.
- Целевая среда, Windows 10/11 Firefox: открыть панель на 10–15 мин при работающем сервисе, следить за RAM в about:memory (Measure) и диспетчере задач (вкл. GPU-процесс), должно остаться кратно ниже ~750 МБ и стабильно. Многократно открыть/закрыть модалки; проскроллить лог вверх под потоком; свернуть вкладку.
- Сверить с Chromium и Linux Firefox — без регрессий визуала.