### PR TITLE
feat(frontend): rework status badge with static glow and ECG wave

### DIFF
--- a/frontend/src/components/status/StatusBar.tsx
+++ b/frontend/src/components/status/StatusBar.tsx
@@ -8,6 +8,33 @@ import { useEffect } from 'react'
 import { apiCall, capitalize } from '../../lib/api'
 import { syncClashApiPort, useAppContext } from '../../lib/store'
 import { cn } from '../../lib/utils'
+import type { ServiceStatus } from '../../lib/types'
+
+function StatusWaveform({ status }: { status: ServiceStatus }) {
+  const isStopped = status === 'stopped'
+  const color = isStopped
+    ? 'color-mix(in srgb, var(--status-badge-stopped-color) 30%, transparent)'
+    : status === 'running'
+      ? 'color-mix(in srgb, var(--status-running-color) 35%, transparent)'
+      : 'color-mix(in srgb, var(--status-pending-color) 35%, transparent)'
+
+  return (
+    <svg aria-hidden="true" className="status-badge-wave" viewBox="0 0 200 36" preserveAspectRatio="none" fill="none">
+      {isStopped ? (
+        <line x1="0" y1="18" x2="200" y2="18" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+      ) : (
+        <path
+          d="M 0,18 L 22,18 L 26,14.5 L 30,18 L 36,18 L 39,21 L 43,4 L 47,30 L 51,18 L 57,13.5 L 63,18 L 112,18 L 116,14.5 L 120,18 L 126,18 L 129,21 L 133,4 L 137,30 L 141,18 L 147,13.5 L 153,18 L 200,18"
+          stroke={color}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+    </svg>
+  )
+}
 
 export function StatusBar({
   onOpenCoreManage,
@@ -45,7 +72,7 @@ export function StatusBar({
   }
 
   async function startService() {
-    setPending('Запуск...')
+    setPending('Запуск сервиса...')
     const result = await apiCall<any>('POST', 'control', { action: 'start' })
     showToast(result.success ? 'XKeen запущен' : `${result.output || result.error}`, result.success ? 'success' : 'error')
     dispatch({ type: 'SET_SERVICE_STATUS', status: result.success ? 'running' : 'stopped' })
@@ -56,7 +83,7 @@ export function StatusBar({
   }
 
   async function stopService() {
-    setPending('Остановка...')
+    setPending('Остановка сервиса...')
     const result = await apiCall<any>('POST', 'control', { action: 'stop' })
     showToast(result.success ? 'XKeen остановлен' : `${result.output || result.error}`, result.success ? 'success' : 'error')
     onRefreshStatus()
@@ -76,22 +103,19 @@ export function StatusBar({
   const statusLabel =
     serviceStatus === 'running' ? 'Сервис запущен' : serviceStatus === 'stopped' ? 'Сервис остановлен' : pendingText || 'Загрузка...'
 
-  const badgeClasses = cn('status-badge-custom', serviceStatus === 'stopped' && 'status-badge-stopped')
-
-  const shineColors = isRunning ? ['#195040', '#34d399', '#195040'] : isPending ? ['#4a3615', '#fbbf24', '#4a3615'] : null
-
-  const badgeBg = isRunning
-    ? { background: 'var(--status-running-bg)', color: 'var(--status-running-color)', border: '1px solid var(--status-running-border)' }
-    : isPending
-      ? { background: 'var(--status-pending-bg)', color: 'var(--status-pending-color)', border: '1px solid var(--status-pending-border)' }
-      : {}
+  const badgeClasses = cn(
+    'status-badge-custom',
+    isRunning && 'status-badge-running',
+    isPending && 'status-badge-pending',
+    serviceStatus === 'stopped' && 'status-badge-stopped'
+  )
 
   return (
     <TooltipProvider delayDuration={500}>
       <div className="border-border bg-card relative z-40 flex shrink-0 flex-col justify-between gap-3 rounded-xl border p-3 sm:p-4 md:flex-row md:items-center">
         <div className="order-2 flex flex-wrap items-center justify-center gap-1.5 md:order-1 md:justify-start">
-          <div className={badgeClasses} style={badgeBg}>
-            {shineColors && <ShineBorder duration={8} borderWidth={2} shineColor={shineColors} />}
+          <div className={badgeClasses}>
+            <StatusWaveform status={serviceStatus} />
             {statusLabel}
           </div>
           <div className="flex items-center gap-1.5">
@@ -157,7 +181,7 @@ export function StatusBar({
             className="rounded-md transition-opacity hover:opacity-85"
           >
             <span
-              className="text-[28px] font-semibold bg-gradient-to-r from-[#00D3F2] via-[#2B7FFF] to-[#155DFC] bg-clip-text text-transparent"
+              className="text-[28px] font-semibold bg-linear-to-r from-[#00D3F2] via-[#2B7FFF] to-[#155DFC] bg-clip-text text-transparent"
             >
               XKeen UI
             </span>

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -138,6 +138,15 @@
   --status-pending-bg: #fffbeb;
   --status-pending-color: #d97706;
   --status-pending-border: #fde68a;
+  --status-running-glow:
+    0 0 6px 1px color-mix(in srgb, var(--status-running-color) 25%, transparent),
+    inset 0 0 6px 0px color-mix(in srgb, var(--status-running-color) 8%, transparent);
+  --status-pending-glow:
+    0 0 6px 1px color-mix(in srgb, var(--status-pending-color) 25%, transparent),
+    inset 0 0 6px 0px color-mix(in srgb, var(--status-pending-color) 8%, transparent);
+  --status-stopped-glow:
+    0 0 6px 1px color-mix(in srgb, var(--status-badge-stopped-color) 20%, transparent),
+    inset 0 0 6px 0px color-mix(in srgb, var(--status-badge-stopped-color) 6%, transparent);
   --log-badge-debug-bg: #fff;
   --log-badge-debug-color: #0f172a;
   --log-badge-debug-border: #cbd5e1;
@@ -197,6 +206,15 @@
   --status-pending-bg: #2a1f0d;
   --status-pending-color: #f59e0b;
   --status-pending-border: #2a1f0d;
+  --status-running-glow:
+    0 0 10px 2px color-mix(in srgb, var(--status-running-color) 40%, transparent),
+    inset 0 0 8px 0px color-mix(in srgb, var(--status-running-color) 14%, transparent);
+  --status-pending-glow:
+    0 0 10px 2px color-mix(in srgb, var(--status-pending-color) 40%, transparent),
+    inset 0 0 8px 0px color-mix(in srgb, var(--status-pending-color) 14%, transparent);
+  --status-stopped-glow:
+    0 0 10px 2px color-mix(in srgb, var(--status-badge-stopped-color) 35%, transparent),
+    inset 0 0 8px 0px color-mix(in srgb, var(--status-badge-stopped-color) 10%, transparent);
   --log-badge-debug-bg: #080e1d;
   --log-badge-debug-color: #fff;
   --log-badge-debug-border: #1e293b;
@@ -348,16 +366,43 @@
   border-radius: 8px;
   border: 1px solid var(--status-badge-border);
   white-space: nowrap;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition:
+    background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
   overflow: hidden;
   user-select: none;
 }
 
+.status-badge-running {
+  background: var(--status-running-bg);
+  color: var(--status-running-color);
+  border-color: color-mix(in srgb, var(--status-running-color) 50%, transparent);
+  box-shadow: var(--status-running-glow);
+}
+
+.status-badge-pending {
+  background: var(--status-pending-bg);
+  color: var(--status-pending-color);
+  border-color: color-mix(in srgb, var(--status-pending-color) 50%, transparent);
+  box-shadow: var(--status-pending-glow);
+}
+
 .status-badge-stopped {
   background: var(--status-badge-stopped-bg);
   color: var(--status-badge-stopped-color);
-  border-color: var(--status-badge-stopped-border);
+  border-color: color-mix(in srgb, var(--status-badge-stopped-color) 50%, transparent);
+  box-shadow: var(--status-stopped-glow);
+}
+
+.status-badge-wave {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 }
 
 @keyframes dark-glow {


### PR DESCRIPTION
Replace infinite ShineBorder animation (steps(240), ~30 repaints/s even when idle) with fully static styling: status-colored glow frame via box-shadow CSS vars and a decorative ECG waveform stretched across the badge background. Stopped state renders a flat line. Transition narrowed from 'all' to color/border/background/box-shadow so cost is paid only on status change.