### PR TITLE
feat(config): безопасное применение конфигов с валидацией и rollback

### DIFF
--- a/backend/src/configs.rs
+++ b/backend/src/configs.rs
@@ -1,11 +1,13 @@
+use crate::controller;
 use crate::logger::log;
 use crate::types::*;
 use axum::extract::{Query, State};
-use axum::response::{IntoResponse, Json};
+use axum::response::{IntoResponse, Json, Response};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 
 #[derive(Serialize)]
 struct ConfigItem {
@@ -16,6 +18,10 @@ struct ConfigItem {
 pub struct ConfigReq {
     file: String,
     content: String,
+    #[serde(default)]
+    apply: bool,
+    #[serde(default)]
+    validate_only: bool,
 }
 #[derive(Deserialize)]
 pub struct DeleteReq {
@@ -175,7 +181,313 @@ fn check_access(file: &str, state: &AppState) -> Result<bool, &'static str> {
     Ok(file.ends_with(".lst"))
 }
 
-pub async fn put_config(State(state): State<AppState>, Json(req): Json<ConfigReq>) -> impl IntoResponse {
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SafeApplyData {
+    applied: bool,
+    rollback_performed: bool,
+    stage: String,
+    validate_only: bool,
+}
+
+struct FileSnapshot {
+    existed: bool,
+    content: Vec<u8>,
+    mode: Option<u32>,
+}
+
+fn is_xkeen_config(file: &str) -> bool {
+    file.ends_with(".lst") || (file.ends_with(".json") && file.starts_with(XKEEN_CONF))
+}
+
+fn normalize_content(file: &str, content: String) -> String {
+    if file.ends_with(".lst") {
+        content.replace("\r\n", "\n")
+    } else {
+        content
+    }
+}
+
+fn safe_apply_response(
+    success: bool, stage: &str, error: Option<String>, applied: bool, rollback_performed: bool, validate_only: bool,
+) -> Json<ApiResponse<SafeApplyData>> {
+    Json(ApiResponse {
+        success,
+        error,
+        data: Some(SafeApplyData {
+            applied,
+            rollback_performed,
+            stage: stage.into(),
+            validate_only,
+        }),
+    })
+}
+
+fn infer_target_core(state: &AppState, file: &str) -> String {
+    if file.starts_with(MIHOMO_CONF) {
+        "mihomo".into()
+    } else if file.starts_with(XRAY_CONF) {
+        "xray".into()
+    } else {
+        controller::current_core_name(state)
+    }
+}
+
+fn get_core_config_paths(state: &AppState, core: &str) -> Vec<String> {
+    let settings = state.settings.read().unwrap();
+    let mut paths = vec![controller::core_config_dir(core).unwrap_or(XRAY_CONF).to_string()];
+    let extra = if core == "mihomo" {
+        settings.append_config_paths.mihomo.clone()
+    } else {
+        settings.append_config_paths.xray.clone()
+    };
+    paths.extend(extra);
+    paths
+}
+
+fn stage_mirror_path(root: &Path, original: &Path) -> Result<PathBuf, String> {
+    let relative = original
+        .strip_prefix("/")
+        .map_err(|_| format!("Не удалось подготовить путь {}", original.display()))?;
+    Ok(root.join(relative))
+}
+
+async fn copy_file_to_stage(source: &Path, stage_root: &Path) -> Result<(), String> {
+    let target = stage_mirror_path(stage_root, source)?;
+    if let Some(parent) = target.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Не удалось подготовить staging-директорию {}: {}", parent.display(), e))?;
+    }
+    tokio::fs::copy(source, &target)
+        .await
+        .map_err(|e| format!("Не удалось скопировать {}: {}", source.display(), e))?;
+    Ok(())
+}
+
+async fn copy_path_to_stage(source: &Path, is_mihomo: bool, stage_root: &Path) -> Result<(), String> {
+    if !source.exists() {
+        return Ok(());
+    }
+    if source.is_dir() {
+        let mut entries = tokio::fs::read_dir(source)
+            .await
+            .map_err(|e| format!("Не удалось открыть {}: {}", source.display(), e))?;
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|e| format!("Не удалось прочитать {}: {}", source.display(), e))?
+        {
+            let path = entry.path();
+            let matches = if is_mihomo {
+                path.extension().map_or(false, |e| e == "yaml" || e == "yml")
+            } else {
+                path.extension().map_or(false, |e| e == "json")
+            };
+            if matches {
+                copy_file_to_stage(&path, stage_root).await?;
+            }
+        }
+        return Ok(());
+    }
+    copy_file_to_stage(source, stage_root).await
+}
+
+async fn create_stage_root() -> Result<PathBuf, String> {
+    let root = std::env::temp_dir().join(format!(
+        "xkeen-ui-safe-apply-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    tokio::fs::create_dir_all(&root)
+        .await
+        .map_err(|e| format!("Не удалось создать staging-директорию {}: {}", root.display(), e))?;
+    Ok(root)
+}
+
+async fn stage_candidate_config(state: &AppState, core: &str, file: &Path, content: &str) -> Result<PathBuf, String> {
+    let stage_root = create_stage_root().await?;
+    let is_mihomo = core == "mihomo";
+    for source in get_core_config_paths(state, core) {
+        copy_path_to_stage(Path::new(&source), is_mihomo, &stage_root).await?;
+    }
+    let staged_target = stage_mirror_path(&stage_root, file)?;
+    write_file_atomically(&staged_target, content.as_bytes(), None).await?;
+    Ok(stage_root)
+}
+
+async fn take_snapshot(path: &Path) -> Result<FileSnapshot, String> {
+    match tokio::fs::metadata(path).await {
+        Ok(metadata) => {
+            let content = tokio::fs::read(path)
+                .await
+                .map_err(|e| format!("Не удалось сохранить snapshot {}: {}", path.display(), e))?;
+            Ok(FileSnapshot {
+                existed: true,
+                content,
+                mode: Some(metadata.permissions().mode()),
+            })
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(FileSnapshot {
+            existed: false,
+            content: Vec::new(),
+            mode: None,
+        }),
+        Err(e) => Err(format!("Не удалось получить метаданные {}: {}", path.display(), e)),
+    }
+}
+
+async fn write_file_atomically(path: &Path, content: &[u8], mode: Option<u32>) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Не удалось определить директорию для {}", path.display()))?;
+    tokio::fs::create_dir_all(parent)
+        .await
+        .map_err(|e| format!("Не удалось создать директорию {}: {}", parent.display(), e))?;
+
+    let tmp_path = parent.join(format!(
+        ".{}.xkeen-ui-tmp-{}",
+        path.file_name().and_then(|n| n.to_str()).unwrap_or("config"),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+
+    if let Err(e) = tokio::fs::write(&tmp_path, content).await {
+        return Err(format!(
+            "Не удалось записать временный файл {}: {}",
+            tmp_path.display(),
+            e
+        ));
+    }
+
+    let desired_mode = if let Some(mode) = mode {
+        Some(mode)
+    } else {
+        tokio::fs::metadata(path)
+            .await
+            .ok()
+            .map(|metadata| metadata.permissions().mode())
+    };
+
+    if let Some(mode) = desired_mode {
+        let _ = tokio::fs::set_permissions(&tmp_path, fs::Permissions::from_mode(mode)).await;
+    }
+
+    if let Err(e) = tokio::fs::rename(&tmp_path, path).await {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(format!("Не удалось атомарно заменить {}: {}", path.display(), e));
+    }
+
+    Ok(())
+}
+
+async fn restore_snapshot(path: &Path, snapshot: &FileSnapshot) -> Result<(), String> {
+    if snapshot.existed {
+        write_file_atomically(path, &snapshot.content, snapshot.mode).await
+    } else {
+        match tokio::fs::remove_file(path).await {
+            Ok(_) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(format!("Не удалось удалить {} при rollback: {}", path.display(), e)),
+        }
+    }
+}
+
+async fn validate_candidate(state: &AppState, core: &str, file: &Path, content: &str) -> Result<(), String> {
+    let stage_root = stage_candidate_config(state, core, file, content).await?;
+    let staged_core_dir = stage_root.join(
+        controller::core_config_dir(core)
+            .ok_or_else(|| "Неизвестное ядро".to_string())?
+            .trim_start_matches('/'),
+    );
+    let result = controller::validate_core_config(core, &staged_core_dir).await;
+    let _ = tokio::fs::remove_dir_all(&stage_root).await;
+    result
+}
+
+async fn restart_with_healthcheck(state: &AppState, core: &str) -> Result<(), String> {
+    if core == "mihomo" {
+        _ = tokio::fs::write(error_log_path(), b"").await;
+    }
+    controller::run_init_command(state, &["restart", "on"]).await?;
+    controller::wait_for_core_healthy(core).await
+}
+
+async fn safe_apply_config(state: &AppState, file: String, content: String) -> Json<ApiResponse<SafeApplyData>> {
+    let _guard = state.service_op_lock.lock().await;
+
+    let target_path = PathBuf::from(&file);
+    let target_core = infer_target_core(state, &file);
+
+    let snapshot = match take_snapshot(&target_path).await {
+        Ok(snapshot) => snapshot,
+        Err(e) => {
+            return safe_apply_response(false, "backup", Some(e), false, false, false);
+        }
+    };
+
+    if !is_xkeen_config(&file) {
+        if let Err(e) = validate_candidate(state, &target_core, &target_path, &content).await {
+            return safe_apply_response(false, "validate", Some(e), false, false, false);
+        }
+    }
+
+    if let Err(e) = write_file_atomically(&target_path, content.as_bytes(), snapshot.mode).await {
+        return safe_apply_response(false, "write", Some(e), false, false, false);
+    }
+
+    match restart_with_healthcheck(state, &target_core).await {
+        Ok(()) => safe_apply_response(true, "completed", None, true, false, false),
+        Err(restart_error) => {
+            if let Err(e) = restore_snapshot(&target_path, &snapshot).await {
+                return safe_apply_response(
+                    false,
+                    "rollback",
+                    Some(format!(
+                        "Сервис не поднялся после применения: {}. Дополнительно не удалось восстановить snapshot: {}",
+                        restart_error, e
+                    )),
+                    false,
+                    false,
+                    false,
+                );
+            }
+
+            if let Err(e) = restart_with_healthcheck(state, &target_core).await {
+                return safe_apply_response(
+                    false,
+                    "rollback",
+                    Some(format!(
+                        "Новый конфиг не применён: {}. Файл откатан, но не удалось вернуть сервис в рабочее состояние: {}",
+                        restart_error, e
+                    )),
+                    false,
+                    false,
+                    false,
+                );
+            }
+
+            safe_apply_response(
+                false,
+                "rollback",
+                Some(format!(
+                    "Новый конфиг не применён: {}. Выполнен автоматический rollback предыдущей рабочей версии.",
+                    restart_error
+                )),
+                false,
+                true,
+                false,
+            )
+        }
+    }
+}
+
+pub async fn put_config(State(state): State<AppState>, Json(req): Json<ConfigReq>) -> Response {
     let is_lst = match check_access(&req.file, &state) {
         Ok(val) => val,
         Err(e) => {
@@ -183,7 +495,8 @@ pub async fn put_config(State(state): State<AppState>, Json(req): Json<ConfigReq
                 success: false,
                 error: Some(e.into()),
                 data: None,
-            });
+            })
+            .into_response();
         }
     };
     let content = if is_lst {
@@ -191,23 +504,49 @@ pub async fn put_config(State(state): State<AppState>, Json(req): Json<ConfigReq
     } else {
         req.content
     };
-    if fs::write(&req.file, content).is_err() {
+
+    if req.validate_only {
+        let target_core = infer_target_core(&state, &req.file);
+        if is_xkeen_config(&req.file) {
+            return safe_apply_response(
+                false,
+                "validate",
+                Some("Для этого файла validate-only не поддерживается".into()),
+                false,
+                false,
+                true,
+            )
+            .into_response();
+        }
+        return match validate_candidate(&state, &target_core, Path::new(&req.file), &content).await {
+            Ok(()) => safe_apply_response(true, "validated", None, false, false, true).into_response(),
+            Err(e) => safe_apply_response(false, "validate", Some(e), false, false, true).into_response(),
+        };
+    }
+
+    if req.apply {
+        return safe_apply_config(&state, req.file, content).await.into_response();
+    }
+
+    if let Err(e) = write_file_atomically(Path::new(&req.file), content.as_bytes(), None).await {
         return Json(ApiResponse::<()> {
             success: false,
-            error: Some("Write error".into()),
+            error: Some(e),
             data: None,
-        });
+        })
+        .into_response();
     }
     Json(ApiResponse::<()> {
         success: true,
         error: None,
         data: None,
     })
+    .into_response()
 }
 
 pub async fn post_config(State(state): State<AppState>, Json(req): Json<ConfigReq>) -> impl IntoResponse {
-    let is_lst = match check_access(&req.file, &state) {
-        Ok(val) => val,
+    match check_access(&req.file, &state) {
+        Ok(_) => {}
         Err(e) => {
             return Json(ApiResponse::<()> {
                 success: false,
@@ -215,7 +554,7 @@ pub async fn post_config(State(state): State<AppState>, Json(req): Json<ConfigRe
                 data: None,
             });
         }
-    };
+    }
     if Path::new(&req.file).exists() {
         return Json(ApiResponse::<()> {
             success: false,
@@ -223,15 +562,11 @@ pub async fn post_config(State(state): State<AppState>, Json(req): Json<ConfigRe
             data: None,
         });
     }
-    let content = if is_lst {
-        req.content.replace("\r\n", "\n")
-    } else {
-        req.content
-    };
-    if fs::write(&req.file, content).is_err() {
+    let content = normalize_content(&req.file, req.content);
+    if let Err(e) = write_file_atomically(Path::new(&req.file), content.as_bytes(), None).await {
         return Json(ApiResponse::<()> {
             success: false,
-            error: Some("Write error".into()),
+            error: Some(e),
             data: None,
         });
     }
@@ -298,4 +633,51 @@ pub async fn patch_config(State(state): State<AppState>, Json(req): Json<RenameR
         error: None,
         data: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lst_content_is_normalized_to_lf() {
+        assert_eq!(
+            normalize_content("/opt/etc/xkeen/test.lst", "a\r\nb\r\n".into()),
+            "a\nb\n"
+        );
+        assert_eq!(
+            normalize_content("/opt/etc/xray/configs/01.json", "a\r\nb\r\n".into()),
+            "a\r\nb\r\n"
+        );
+    }
+
+    #[test]
+    fn path_allowlist_supports_files_and_directories() {
+        let root = std::env::temp_dir().join(format!("xkeen-ui-config-test-{}", std::process::id()));
+        let dir = root.join("configs");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = root.join("config.yaml");
+        std::fs::write(&file, "port: 7890").unwrap();
+
+        let prefixes = vec![dir.to_string_lossy().into_owned(), file.to_string_lossy().into_owned()];
+
+        assert!(is_path_allowed(&dir.join("01.json").to_string_lossy(), &prefixes));
+        assert!(is_path_allowed(&file.to_string_lossy(), &prefixes));
+        assert!(!is_path_allowed(
+            &root.join("other/01.json").to_string_lossy(),
+            &prefixes
+        ));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn stage_paths_preserve_absolute_layout() {
+        let stage = Path::new("/tmp/stage-root");
+        let original = Path::new("/opt/etc/mihomo/config.yaml");
+        assert_eq!(
+            stage_mirror_path(stage, original).unwrap(),
+            PathBuf::from("/tmp/stage-root/opt/etc/mihomo/config.yaml")
+        );
+    }
 }

--- a/backend/src/configs.rs
+++ b/backend/src/configs.rs
@@ -184,7 +184,6 @@ fn check_access(file: &str, state: &AppState) -> Result<bool, &'static str> {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SafeApplyData {
-    applied: bool,
     rollback_performed: bool,
     stage: String,
     validate_only: bool,
@@ -209,13 +208,12 @@ fn normalize_content(file: &str, content: String) -> String {
 }
 
 fn safe_apply_response(
-    success: bool, stage: &str, error: Option<String>, applied: bool, rollback_performed: bool, validate_only: bool,
+    success: bool, stage: &str, error: Option<String>, rollback_performed: bool, validate_only: bool,
 ) -> Json<ApiResponse<SafeApplyData>> {
     Json(ApiResponse {
         success,
         error,
         data: Some(SafeApplyData {
-            applied,
             rollback_performed,
             stage: stage.into(),
             validate_only,
@@ -427,22 +425,22 @@ async fn safe_apply_config(state: &AppState, file: String, content: String) -> J
     let snapshot = match take_snapshot(&target_path).await {
         Ok(snapshot) => snapshot,
         Err(e) => {
-            return safe_apply_response(false, "backup", Some(e), false, false, false);
+            return safe_apply_response(false, "backup", Some(e), false, false);
         }
     };
 
     if !is_xkeen_config(&file) {
         if let Err(e) = validate_candidate(state, &target_core, &target_path, &content).await {
-            return safe_apply_response(false, "validate", Some(e), false, false, false);
+            return safe_apply_response(false, "validate", Some(e), false, false);
         }
     }
 
     if let Err(e) = write_file_atomically(&target_path, content.as_bytes(), snapshot.mode).await {
-        return safe_apply_response(false, "write", Some(e), false, false, false);
+        return safe_apply_response(false, "write", Some(e), false, false);
     }
 
     match restart_with_healthcheck(state, &target_core).await {
-        Ok(()) => safe_apply_response(true, "completed", None, true, false, false),
+        Ok(()) => safe_apply_response(true, "completed", None, false, false),
         Err(restart_error) => {
             if let Err(e) = restore_snapshot(&target_path, &snapshot).await {
                 return safe_apply_response(
@@ -452,7 +450,6 @@ async fn safe_apply_config(state: &AppState, file: String, content: String) -> J
                         "Сервис не поднялся после применения: {}. Дополнительно не удалось восстановить snapshot: {}",
                         restart_error, e
                     )),
-                    false,
                     false,
                     false,
                 );
@@ -468,7 +465,6 @@ async fn safe_apply_config(state: &AppState, file: String, content: String) -> J
                     )),
                     false,
                     false,
-                    false,
                 );
             }
 
@@ -479,7 +475,6 @@ async fn safe_apply_config(state: &AppState, file: String, content: String) -> J
                     "Новый конфиг не применён: {}. Выполнен автоматический rollback предыдущей рабочей версии.",
                     restart_error
                 )),
-                false,
                 true,
                 false,
             )
@@ -513,14 +508,13 @@ pub async fn put_config(State(state): State<AppState>, Json(req): Json<ConfigReq
                 "validate",
                 Some("Для этого файла validate-only не поддерживается".into()),
                 false,
-                false,
                 true,
             )
             .into_response();
         }
         return match validate_candidate(&state, &target_core, Path::new(&req.file), &content).await {
-            Ok(()) => safe_apply_response(true, "validated", None, false, false, true).into_response(),
-            Err(e) => safe_apply_response(false, "validate", Some(e), false, false, true).into_response(),
+            Ok(()) => safe_apply_response(true, "validated", None, false, true).into_response(),
+            Err(e) => safe_apply_response(false, "validate", Some(e), false, true).into_response(),
         };
     }
 

--- a/backend/src/controller.rs
+++ b/backend/src/controller.rs
@@ -8,7 +8,8 @@ use nix::unistd::{Gid, Pid, setgid, setsid};
 use serde::Deserialize;
 use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tokio::fs::{self, set_permissions};
 use tokio::process::Command;
 
@@ -17,6 +18,34 @@ pub struct ControlReq {
     action: String,
     #[serde(default)]
     core: String,
+}
+
+pub fn normalize_core_name(name: &str) -> Option<&'static str> {
+    match name {
+        "xray" => Some("xray"),
+        "mihomo" => Some("mihomo"),
+        _ => None,
+    }
+}
+
+pub fn core_binary_path(core: &str) -> Option<&'static str> {
+    match normalize_core_name(core) {
+        Some("xray") => Some("/opt/sbin/xray"),
+        Some("mihomo") => Some("/opt/sbin/mihomo"),
+        _ => None,
+    }
+}
+
+pub fn core_config_dir(core: &str) -> Option<&'static str> {
+    match normalize_core_name(core) {
+        Some("xray") => Some(XRAY_CONF),
+        Some("mihomo") => Some(MIHOMO_CONF),
+        _ => None,
+    }
+}
+
+pub fn current_core_name(state: &AppState) -> String {
+    state.core.read().unwrap().name.clone()
 }
 
 pub fn find_init_file(log_enabled: bool) -> Option<String> {
@@ -122,11 +151,12 @@ pub fn get_pid(name: &str) -> Vec<i32> {
 }
 
 pub async fn soft_restart(core: &str) -> Result<(), String> {
+    let core = normalize_core_name(core).ok_or_else(|| "Неизвестное ядро".to_string())?;
     for pid in get_pid(core) {
         _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
     }
 
-    let mut cmd = Command::new(core);
+    let mut cmd = Command::new(core_binary_path(core).unwrap_or(core));
     match core {
         "mihomo" => {
             cmd.env("CLASH_HOME_DIR", MIHOMO_CONF);
@@ -168,6 +198,32 @@ pub async fn soft_restart(core: &str) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+pub fn is_core_running(core: &str) -> bool {
+    normalize_core_name(core).is_some_and(|name| !get_pid(name).is_empty())
+}
+
+pub async fn wait_for_core_healthy(core: &str) -> Result<(), String> {
+    let core = normalize_core_name(core).ok_or_else(|| "Неизвестное ядро".to_string())?;
+    let start_deadline = tokio::time::Instant::now() + Duration::from_secs(6);
+
+    loop {
+        if is_core_running(core) {
+            break;
+        }
+        if tokio::time::Instant::now() >= start_deadline {
+            return Err(format!("{} не запустился за отведённое время", core));
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    if is_core_running(core) {
+        Ok(())
+    } else {
+        Err(format!("{} запустился, но быстро завершился", core))
+    }
 }
 
 pub async fn get_control(State(state): State<AppState>) -> impl IntoResponse {
@@ -243,10 +299,11 @@ pub async fn get_control(State(state): State<AppState>) -> impl IntoResponse {
     )
 }
 
-async fn check_core_config(core: &str) -> Result<(), String> {
+pub async fn check_core_config_at(core: &str, dir: &Path) -> Result<(), String> {
+    let core = normalize_core_name(core).ok_or_else(|| "Неизвестное ядро".to_string())?;
     if core == "xray" {
-        fs::create_dir_all(XRAY_CONF).await.ok();
-        let has_json = std::fs::read_dir(XRAY_CONF)
+        fs::create_dir_all(dir).await.ok();
+        let has_json = std::fs::read_dir(dir)
             .map(|dir| {
                 dir.flatten()
                     .any(|e| e.path().extension().map_or(false, |x| x == "json"))
@@ -261,11 +318,66 @@ async fn check_core_config(core: &str) -> Result<(), String> {
     Ok(())
 }
 
+pub async fn check_core_config(core: &str) -> Result<(), String> {
+    let dir = core_config_dir(core).ok_or_else(|| "Неизвестное ядро".to_string())?;
+    check_core_config_at(core, Path::new(dir)).await
+}
+
+pub async fn validate_core_config(core: &str, dir: &Path) -> Result<(), String> {
+    let core = normalize_core_name(core).ok_or_else(|| "Неизвестное ядро".to_string())?;
+    check_core_config_at(core, dir).await?;
+
+    let binary = core_binary_path(core).ok_or_else(|| "Не найден бинарник ядра".to_string())?;
+    let mut cmd = Command::new(binary);
+    match core {
+        "xray" => {
+            cmd.args(["run", "-test", "-confdir"]);
+            cmd.arg(dir);
+            cmd.env("XRAY_LOCATION_ASSET", XRAY_ASSET);
+        }
+        "mihomo" => {
+            let config_file: PathBuf = dir.join("config.yaml");
+            cmd.args(["-t", "-d"]);
+            cmd.arg(dir);
+            cmd.arg("-f");
+            cmd.arg(&config_file);
+        }
+        _ => unreachable!(),
+    }
+
+    let output = cmd
+        .output()
+        .await
+        .map_err(|e| format!("Ошибка запуска валидатора: {e}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let details = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("код {}", output.status)
+    };
+    Err(details)
+}
+
 pub async fn post_control(State(state): State<AppState>, Json(req): Json<ControlReq>) -> impl IntoResponse {
+    let _guard = state.service_op_lock.lock().await;
     match req.action.as_str() {
         "switchCore" => {
+            let Some(target_core) = normalize_core_name(&req.core) else {
+                return Json(ApiResponse {
+                    success: false,
+                    error: Some("Bad core".into()),
+                    data: None,
+                });
+            };
             let old = state.core.read().unwrap().name.clone();
-            if old == req.core {
+            if old == target_core {
                 return Json(ApiResponse {
                     success: true,
                     error: None,
@@ -288,28 +400,28 @@ pub async fn post_control(State(state): State<AppState>, Json(req): Json<Control
             if let Ok(content) = fs::read_to_string(&init_file).await {
                 let new_content = content.replace(
                     &format!("name_client=\"{}\"", old),
-                    &format!("name_client=\"{}\"", req.core),
+                    &format!("name_client=\"{}\"", target_core),
                 );
                 _ = fs::write(&init_file, new_content).await;
                 _ = set_permissions(&init_file, Permissions::from_mode(0o755)).await;
             }
 
-            *state.core.write().unwrap() = get_core_info(&req.core);
+            *state.core.write().unwrap() = get_core_info(target_core);
 
-            if let Err(e) = check_core_config(&req.core).await {
+            if let Err(e) = check_core_config(target_core).await {
                 log("ERROR", e);
                 return Json(ApiResponse {
                     success: false,
                     error: Some(format!(
                         "Не удалось запустить {}{}",
-                        &req.core[..1].to_uppercase(),
-                        &req.core[1..]
+                        &target_core[..1].to_uppercase(),
+                        &target_core[1..]
                     )),
                     data: None,
                 });
             }
 
-            if req.core != "xray" {
+            if target_core != "xray" {
                 _ = fs::write(error_log_path(), b"").await;
             }
 
@@ -322,7 +434,14 @@ pub async fn post_control(State(state): State<AppState>, Json(req): Json<Control
             }
         }
         "softRestart" => {
-            if let Err(e) = soft_restart(&req.core).await {
+            let Some(target_core) = normalize_core_name(&req.core) else {
+                return Json(ApiResponse {
+                    success: false,
+                    error: Some("Bad core".into()),
+                    data: None,
+                });
+            };
+            if let Err(e) = soft_restart(target_core).await {
                 return Json(ApiResponse {
                     success: false,
                     error: Some(e),

--- a/backend/src/controller.rs
+++ b/backend/src/controller.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::fs::{self, set_permissions};
 use tokio::process::Command;
+use yaml_rust2::YamlLoader;
 
 #[derive(Deserialize)]
 pub struct ControlReq {
@@ -204,6 +205,125 @@ pub fn is_core_running(core: &str) -> bool {
     normalize_core_name(core).is_some_and(|name| !get_pid(name).is_empty())
 }
 
+enum MihomoControllerTarget {
+    Tcp {
+        port: String,
+        secret: Option<String>,
+    },
+    Unix {
+        path: PathBuf,
+    },
+}
+
+fn parse_mihomo_controller_target(dir: &Path, content: &str) -> Option<MihomoControllerTarget> {
+    let docs = YamlLoader::load_from_str(content).ok()?;
+    let doc = docs.first()?;
+
+    if let Some(raw_path) = doc["external-controller-unix"].as_str().map(str::trim).filter(|s| !s.is_empty()) {
+        let path = Path::new(raw_path);
+        return Some(MihomoControllerTarget::Unix {
+            path: if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                dir.join(path)
+            },
+        });
+    }
+
+    let controller = doc["external-controller"].as_str()?.trim();
+    let (_, port) = controller.rsplit_once(':')?;
+    if port.is_empty() || !port.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+
+    let secret = doc["secret"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned);
+
+    Some(MihomoControllerTarget::Tcp {
+        port: port.to_string(),
+        secret,
+    })
+}
+
+async fn check_mihomo_controller_once(target: &MihomoControllerTarget) -> Result<(), String> {
+    match target {
+        MihomoControllerTarget::Tcp { port, secret } => {
+            let client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(1))
+                .build()
+                .map_err(|e| format!("Не удалось создать HTTP клиент: {e}"))?;
+            let mut request = client.get(format!("http://127.0.0.1:{port}/version"));
+            if let Some(secret) = secret {
+                request = request.header("Authorization", format!("Bearer {secret}"));
+            }
+            let response = request
+                .send()
+                .await
+                .map_err(|e| format!("HTTP запрос к controller API завершился ошибкой: {e}"))?;
+            if response.status().is_success() {
+                Ok(())
+            } else {
+                Err(format!("controller API вернул {}", response.status()))
+            }
+        }
+        MihomoControllerTarget::Unix { path } => {
+            let client = reqwest::Client::builder()
+                .unix_socket(path.clone())
+                .timeout(Duration::from_secs(1))
+                .build()
+                .map_err(|e| format!("Не удалось создать HTTP клиент для unix-сокета: {e}"))?;
+            let response = client
+                .get("http://127.0.0.1/version")
+                .send()
+                .await
+                .map_err(|e| format!("HTTP запрос к controller API через unix-сокет завершился ошибкой: {e}"))?;
+            if response.status().is_success() {
+                Ok(())
+            } else {
+                Err(format!("controller API вернул {}", response.status()))
+            }
+        }
+    }
+}
+
+async fn wait_for_mihomo_controller_ready() -> Result<(), String> {
+    let config_path = Path::new(MIHOMO_CONF).join("config.yaml");
+    let content = fs::read_to_string(&config_path)
+        .await
+        .map_err(|e| format!("Не удалось прочитать {}: {}", config_path.display(), e))?;
+
+    let Some(target) = parse_mihomo_controller_target(Path::new(MIHOMO_CONF), &content) else {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        return if is_core_running("mihomo") {
+            Ok(())
+        } else {
+            Err("mihomo запустился, но быстро завершился".into())
+        };
+    };
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(8);
+
+    loop {
+        if !is_core_running("mihomo") {
+            return Err("mihomo запустился, но завершился до готовности controller API".into());
+        }
+
+        let last_error = match check_mihomo_controller_once(&target).await {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!("mihomo не подтвердил готовность controller API: {}", last_error));
+        }
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
 pub async fn wait_for_core_healthy(core: &str) -> Result<(), String> {
     let core = normalize_core_name(core).ok_or_else(|| "Неизвестное ядро".to_string())?;
     let start_deadline = tokio::time::Instant::now() + Duration::from_secs(6);
@@ -218,11 +338,54 @@ pub async fn wait_for_core_healthy(core: &str) -> Result<(), String> {
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
 
+    if core == "mihomo" {
+        return wait_for_mihomo_controller_ready().await;
+    }
+
     tokio::time::sleep(Duration::from_secs(2)).await;
     if is_core_running(core) {
         Ok(())
     } else {
         Err(format!("{} запустился, но быстро завершился", core))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_mihomo_tcp_controller_settings() {
+        let config = r#"
+external-controller: 0.0.0.0:9090
+secret: test-secret
+"#;
+
+        let target = parse_mihomo_controller_target(Path::new(MIHOMO_CONF), config);
+
+        match target {
+            Some(MihomoControllerTarget::Tcp { port, secret }) => {
+                assert_eq!(port, "9090");
+                assert_eq!(secret.as_deref(), Some("test-secret"));
+            }
+            _ => panic!("expected tcp controller target"),
+        }
+    }
+
+    #[test]
+    fn parses_mihomo_unix_controller_settings() {
+        let config = r#"
+external-controller-unix: ./clash.sock
+"#;
+
+        let target = parse_mihomo_controller_target(Path::new(MIHOMO_CONF), config);
+
+        match target {
+            Some(MihomoControllerTarget::Unix { path }) => {
+                assert_eq!(path, Path::new(MIHOMO_CONF).join("clash.sock"));
+            }
+            _ => panic!("expected unix controller target"),
+        }
     }
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -25,7 +25,7 @@ use std::io::{self, Write};
 use std::net::SocketAddr;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::process::{exit};
+use std::process::exit;
 use std::sync::{Arc, RwLock};
 use tokio::sync::broadcast;
 use tower_http::cors::CorsLayer;
@@ -118,7 +118,12 @@ fn setup_process_logging() {
 
     if !stdio_is_interactive() {
         if let Err(e) = redirect_stderr_to_process_log() {
-            eprintln!("{} {}: {}", " Не удалось перенаправить stderr в".red().bold(), XKEEN_UI_LOG, e);
+            eprintln!(
+                "{} {}: {}",
+                " Не удалось перенаправить stderr в".red().bold(),
+                XKEEN_UI_LOG,
+                e
+            );
         }
     }
 }
@@ -259,8 +264,7 @@ async fn main() {
     }
 
     let version: &'static str = Box::leak(format!("{} ({})", VERSION, get_arch()).into_boxed_str());
-    let mut command = <Cli as clap::CommandFactory>::command()
-        .version(version);
+    let mut command = <Cli as clap::CommandFactory>::command().version(version);
 
     if std::env::args().any(|arg| arg == "-h" || arg == "--help") {
         command.print_help().unwrap();
@@ -408,6 +412,7 @@ async fn main() {
         log_tx: log_tx_arc,
         log_watcher: Arc::new(tokio::sync::Mutex::new(None)),
         app_config_lock: Arc::new(tokio::sync::Mutex::new(())),
+        service_op_lock: Arc::new(tokio::sync::Mutex::new(())),
         debug: cli.debug,
     };
     version::start_update_checker(state.clone());

--- a/backend/src/types.rs
+++ b/backend/src/types.rs
@@ -105,6 +105,7 @@ pub struct AppState {
     pub log_tx: Arc<broadcast::Sender<String>>,
     pub log_watcher: Arc<Mutex<Option<AbortHandle>>>,
     pub app_config_lock: Arc<Mutex<()>>,
+    pub service_op_lock: Arc<Mutex<()>>,
     pub debug: bool,
 }
 

--- a/frontend/src/components/configuration/ConfigPanel.tsx
+++ b/frontend/src/components/configuration/ConfigPanel.tsx
@@ -527,7 +527,6 @@ export function ConfigPanel({ onOpenImport, onOpenTemplate, onOpenGeoScan, onRef
         success: boolean
         error?: string
         data?: {
-          applied?: boolean
           rollbackPerformed?: boolean
           stage?: string
         }

--- a/frontend/src/components/configuration/ConfigPanel.tsx
+++ b/frontend/src/components/configuration/ConfigPanel.tsx
@@ -513,6 +513,7 @@ export function ConfigPanel({ onOpenImport, onOpenTemplate, onOpenGeoScan, onRef
     const cfg = configsRef.current[activeIndexRef.current]
     if (!cfg || !editorRef.current) return
     const content = editorRef.current.getValue()
+    const previousServiceStatus = serviceStatus
     if (!content.trim()) return showToast('Файл пустой', 'error')
     if (!editorRef.current.isValid(cfg.file)) return showToast('Файл содержит ошибки', 'error')
     if (!force && isGuiActive(cfg) && hasComments(cfg.savedContent)) {
@@ -525,14 +526,18 @@ export function ConfigPanel({ onOpenImport, onOpenTemplate, onOpenGeoScan, onRef
       const saveResult = await apiCall<{
         success: boolean
         error?: string
-        rollbackPerformed?: boolean
-        stage?: string
+        data?: {
+          applied?: boolean
+          rollbackPerformed?: boolean
+          stage?: string
+        }
       }>('PUT', 'configs', { file: cfg.file, content, apply: true })
       if (!saveResult.success) {
-        const errorText = saveResult.rollbackPerformed
-          ? `Ошибка применения (${saveResult.stage ?? 'rollback'}): ${saveResult.error}`
-          : `Ошибка применения (${saveResult.stage ?? 'unknown'}): ${saveResult.error}`
-        dispatch({ type: 'SET_SERVICE_STATUS', status: saveResult.rollbackPerformed ? 'running' : 'stopped' })
+        const stage = saveResult.data?.stage ?? 'unknown'
+        const rollbackPerformed = saveResult.data?.rollbackPerformed === true
+        const statusPreserved = rollbackPerformed || stage === 'backup' || stage === 'validate' || stage === 'write'
+        const errorText = `Ошибка применения (${rollbackPerformed ? 'rollback' : stage}): ${saveResult.error}`
+        dispatch({ type: 'SET_SERVICE_STATUS', status: statusPreserved ? previousServiceStatus : 'stopped' })
         return showToast(errorText, 'error')
       }
 
@@ -543,7 +548,7 @@ export function ConfigPanel({ onOpenImport, onOpenTemplate, onOpenGeoScan, onRef
       dispatch({ type: 'SET_SERVICE_STATUS', status: 'running' })
       syncClashApiPort(200)
     } catch (e: any) {
-      dispatch({ type: 'SET_SERVICE_STATUS', status: 'stopped' })
+      dispatch({ type: 'SET_SERVICE_STATUS', status: previousServiceStatus })
       showToast(`Ошибка применения: ${e.message}`, 'error')
     }
   }

--- a/frontend/src/components/configuration/ConfigPanel.tsx
+++ b/frontend/src/components/configuration/ConfigPanel.tsx
@@ -33,7 +33,6 @@ import {
   IconTrash,
   IconX,
 } from '@tabler/icons-react'
-import * as jsyaml from 'js-yaml'
 import { useCallback, useEffect, useMemo, useRef, useState, memo } from 'react'
 import { apiCall, clashFetch, getFileLanguage } from '../../lib/api'
 import { LazyBoundary, lazyLoad, useLazyMount } from '../../lib/loader'
@@ -521,26 +520,31 @@ export function ConfigPanel({ onOpenImport, onOpenTemplate, onOpenGeoScan, onRef
       dispatch({ type: 'SHOW_MODAL', modal: 'showCommentsWarningModal', show: true })
       return
     }
-    const saveResult = await apiCall<{ success: boolean; error?: string }>('PUT', 'configs', { file: cfg.file, content })
-    if (!saveResult.success) return showToast(`Ошибка сохранения: ${saveResult.error}`, 'error')
-    editorRef.current.setSavedContent(content)
-    dispatch({ type: 'SAVE_CONFIG', index: activeIndexRef.current, content })
-    saveViewState(cfg.file, false)
     dispatch({ type: 'SET_SERVICE_STATUS', status: 'pending', pendingText: 'Перезапуск...' })
-    const lang = getFileLanguage(cfg.file)
-    const r = await apiCall<{ success: boolean; error?: string }>('POST', 'control', {
-      action:
-        !xkeenConfigs.some((c) => c.file === cfg.file) &&
-          (lang === 'json' || lang === 'yaml') &&
-          !hasCriticalChanges(cfg.savedContent, content, lang)
-          ? 'softRestart'
-          : 'hardRestart',
-      core: currentCore,
-    })
-    showToast(r?.success ? 'Изменения применены' : `Ошибка: ${r?.error}`, r?.success ? 'success' : 'error')
-    dispatch({ type: 'SET_SERVICE_STATUS', status: r?.success ? 'running' : 'stopped' })
-    if (r?.success) {
+    try {
+      const saveResult = await apiCall<{
+        success: boolean
+        error?: string
+        rollbackPerformed?: boolean
+        stage?: string
+      }>('PUT', 'configs', { file: cfg.file, content, apply: true })
+      if (!saveResult.success) {
+        const errorText = saveResult.rollbackPerformed
+          ? `Ошибка применения (${saveResult.stage ?? 'rollback'}): ${saveResult.error}`
+          : `Ошибка применения (${saveResult.stage ?? 'unknown'}): ${saveResult.error}`
+        dispatch({ type: 'SET_SERVICE_STATUS', status: saveResult.rollbackPerformed ? 'running' : 'stopped' })
+        return showToast(errorText, 'error')
+      }
+
+      editorRef.current.setSavedContent(content)
+      dispatch({ type: 'SAVE_CONFIG', index: activeIndexRef.current, content })
+      saveViewState(cfg.file, false)
+      showToast('Изменения применены', 'success')
+      dispatch({ type: 'SET_SERVICE_STATUS', status: 'running' })
       syncClashApiPort(200)
+    } catch (e: any) {
+      dispatch({ type: 'SET_SERVICE_STATUS', status: 'stopped' })
+      showToast(`Ошибка применения: ${e.message}`, 'error')
     }
   }
 
@@ -813,7 +817,7 @@ export function ConfigPanel({ onOpenImport, onOpenTemplate, onOpenGeoScan, onRef
                           <IconRefresh data-icon="inline-start" /> Применить
                         </Button>
                       </TooltipTrigger>
-                      <TooltipContent>Сохранить и перезапустить</TooltipContent>
+                      <TooltipContent>Сохранить и перезапустить. При сбое выполняется автоматический rollback.</TooltipContent>
                     </Tooltip>
                     <Button size="default" disabled={!canSave} onClick={() => saveCurrentConfig()}>
                       <IconDeviceFloppy data-icon="inline-start" /> Сохранить
@@ -898,24 +902,4 @@ export function ConfigPanel({ onOpenImport, onOpenTemplate, onOpenGeoScan, onRef
 
 function hasComments(content: string) {
   return /(?<!:)\/\/|\/\*[\s\S]*?\*\//.test(content) || /^\s*#/m.test(content)
-}
-
-function hasCriticalChanges(oldContent: string, newContent: string, language: string): boolean {
-  try {
-    if (language === 'yaml') {
-      const o = jsyaml.load(oldContent) as Record<string, unknown>
-      const n = jsyaml.load(newContent) as Record<string, unknown>
-      return ['listeners', 'redir-port', 'tproxy-port'].some((f) => JSON.stringify(o?.[f]) !== JSON.stringify(n?.[f]))
-    }
-    if (language === 'json') {
-      const o = JSON.parse(stripJsonComments(oldContent))
-      const n = JSON.parse(stripJsonComments(newContent))
-      const clean = (arr: Record<string, unknown>[]) =>
-        (arr || []).map((item) => Object.fromEntries(Object.entries(item).filter(([k]) => k !== 'sniffing')))
-      return JSON.stringify(clean(o?.inbounds)) !== JSON.stringify(clean(n?.inbounds))
-    }
-  } catch {
-    return false
-  }
-  return false
 }


### PR DESCRIPTION
Переделал применение конфигов из UI так, чтобы было сложнее случайно уронить рабочую конфигурацию.

Теперь логика такая:

* при нажатии "Применить" конфиг сначала проверяется самим ядром (xray или mihomo) во временной staging-копии;
* fast-path с softRestart убран, и теперь apply всегда идёт через полный restart, потому что только так можно одинаково надёжно проверить реальный подъём сервиса после применения и гарантированно выполнить rollback при неудачном запуске;
* если проверка проходит, файл записывается и сервис перезапускается;
* если после применения сервис не смог нормально подняться, выполняется автоматический откат на предыдущую рабочую версию;
* в UI тоже добавлено явное упоминание, что при сбое есть rollback.

### Что это даёт

Раньше можно было сохранить конфиг, перезапустить сервис и уже потом увидеть, что он не стартует.

Теперь перед применением есть дополнительная проверка не только на уровень синтаксиса в редакторе, а именно на то, что сам xray/mihomo принимает этот конфиг как рабочий.

А если проблема всё же всплывёт уже на рестарте, конфиг автоматически откатится назад.
