### PR TITLE
fix: keep modal open after delete backup

### DIFF
--- a/frontend/src/components/modals/Backups.tsx
+++ b/frontend/src/components/modals/Backups.tsx
@@ -349,7 +349,7 @@ export function BackupsModal({ open, onOpenChange, onRefreshConfigs }: Props) {
         </DialogContent>
       </Dialog>
 
-      <AlertDialog open={!!confirmAction} onOpenChange={(next) => !next && closeConfirm()}>
+      <AlertDialog open={!!confirmAction} onOpenChange={(next) => !next}>
         <AlertDialogContent size="sm">
           <AlertDialogHeader>
             <AlertDialogMedia className={activeDialogAction?.type === 'delete' ? 'bg-destructive/10 text-destructive' : undefined}>

--- a/frontend/src/components/modals/Backups.tsx
+++ b/frontend/src/components/modals/Backups.tsx
@@ -1,7 +1,6 @@
 import {
   AlertDialog,
   AlertDialogAction,
-  AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
@@ -202,7 +201,7 @@ export function BackupsModal({ open, onOpenChange, onRefreshConfigs }: Props) {
   )
 
   const closeConfirm = useCallback(() => {
-    if (pendingAction === null) setConfirmAction(null)
+    if (pendingAction === null) setTimeout(() => setConfirmAction(null), 0)
   }, [pendingAction])
 
   const submitConfirm = useCallback(async () => {
@@ -350,7 +349,13 @@ export function BackupsModal({ open, onOpenChange, onRefreshConfigs }: Props) {
       </Dialog>
 
       <AlertDialog open={!!confirmAction} onOpenChange={(next) => !next}>
-        <AlertDialogContent size="sm">
+        <AlertDialogContent
+          size="sm"
+          onEscapeKeyDown={(event) => {
+            event.preventDefault()
+            closeConfirm()
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogMedia className={activeDialogAction?.type === 'delete' ? 'bg-destructive/10 text-destructive' : undefined}>
               {activeDialogAction?.type === 'delete' ? <IconTrash /> : <IconAlertTriangle />}
@@ -367,7 +372,9 @@ export function BackupsModal({ open, onOpenChange, onRefreshConfigs }: Props) {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={pendingAction !== null}>Отмена</AlertDialogCancel>
+            <Button variant="outline" disabled={pendingAction !== null} onClick={closeConfirm}>
+              Отмена
+            </Button>
             <AlertDialogAction
               variant={activeDialogAction?.type === 'delete' ? 'destructive' : 'default'}
               onClick={() => void submitConfirm()}


### PR DESCRIPTION
Немного раздражает, когда удаляешь бэкап и модалка закрывается, приходится переоткрывать заново через контекстное меню по 100 раз
Предлагаю держать ее открытой после удаления бэкапа. Пользователь сам закроет окно